### PR TITLE
Handle setup state before starting Herd Vote

### DIFF
--- a/src/app/[lang]/apps/herd-vote/page.tsx
+++ b/src/app/[lang]/apps/herd-vote/page.tsx
@@ -13,7 +13,14 @@ export default function HerdVoteAdminPage() {
   const { lang } = useParams<{ lang: string }>()
 
   const [gameCode, setGameCode] = useState<string>('')
-  const [gameStatus, setGameStatus] = useState<'waiting' | 'configuring' | 'running' | 'finished'>('waiting')
+  const [gameStatus, setGameStatus] = useState<
+    | 'waiting'
+    | 'configuring'
+    | 'running'
+    | 'finished'
+    | 'setup'
+    | 'active'
+  >('waiting')
   const [categories, setCategories] = useState<Category[]>([])
   const [selectedCat, setSelectedCat] = useState<string>('')
 
@@ -93,7 +100,16 @@ export default function HerdVoteAdminPage() {
         }
         if (gr && gr.ok) {
           const gj = await gr.json()
-          if (gj?.status) setGameStatus(gj.status)
+          if (gj?.status) {
+            const status = String(gj.status)
+            setGameStatus(
+              status === 'setup'
+                ? 'configuring'
+                : status === 'active'
+                ? 'running'
+                : (status as any)
+            )
+          }
         }
       } catch {}
     }

--- a/src/app/api/games/[code]/lock-lobby/route.ts
+++ b/src/app/api/games/[code]/lock-lobby/route.ts
@@ -18,7 +18,7 @@ export async function POST(req: Request, context: any) {
     return NextResponse.json({ error: 'Lobby already closed' }, { status: 400 })
   }
 
-  game.status = 'active'
+  game.status = 'setup'
   // voliteľne si vynuluj pomocné polia
   ;(game as any).usedQuestionIds = []
   game.rounds = game.rounds ?? []

--- a/src/app/api/games/[code]/start/route.ts
+++ b/src/app/api/games/[code]/start/route.ts
@@ -14,8 +14,8 @@ export async function POST(_req: Request, context: any) {
     return NextResponse.json({ error: 'No rounds configured' }, { status: 400 })
   }
 
-  // povol prechod len z 'waiting' alebo 'active'
-  if (game.status !== 'waiting' && game.status !== 'active') {
+  // povol prechod len z 'waiting' alebo 'setup'
+  if (game.status !== 'waiting' && game.status !== 'setup') {
     return NextResponse.json({ error: `Invalid state: ${game.status}` }, { status: 400 })
   }
 


### PR DESCRIPTION
## Summary
- mark games as `setup` when lobby closes instead of immediately `active`
- allow starting games from `setup` state and move them to `active`
- map server statuses to admin UI equivalents so `setup` and `active` become `configuring` and `running`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install vitest` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a6ea81a08327bef918f9b2945d8f