### PR TITLE
Secure Herd Vote admin area with authentication

### DIFF
--- a/src/app/[lang]/apps/herd-vote/page.tsx
+++ b/src/app/[lang]/apps/herd-vote/page.tsx
@@ -2,8 +2,9 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import { useParams } from 'next/navigation'
+import { useParams, useRouter } from 'next/navigation'
 import type { Player, Round } from '@/lib/herdvote/store'
+import { useAuth } from '@/hooks/useAuth'
 
 type Category = { name: string; count: number }
 type Mode = 'classic' | 'podium'
@@ -20,6 +21,12 @@ function mapStatus(status: string): GameStatus {
 export default function HerdVoteAdminPage() {
   // Lang získame zo URL cez useParams (vyhneme sa typovým „PageProps“ problémom)
   const { lang } = useParams<{ lang: string }>()
+  const router = useRouter()
+  const { user, loading } = useAuth()
+
+  useEffect(() => {
+    if (!loading && !user) router.replace('/login')
+  }, [loading, user, router])
 
   const [gameCode, setGameCode] = useState<string>('')
   const [gameStatus, setGameStatus] = useState<GameStatus>('waiting')
@@ -186,6 +193,14 @@ export default function HerdVoteAdminPage() {
     const urlLang = typeof lang === 'string' ? lang : ''
     return `${origin}/${urlLang}/play/${gameCode}`
   }, [gameCode, lang])
+
+  if (loading || !user) {
+    return (
+      <div className="mx-auto max-w-3xl p-6">
+        <p>Na spustenie hry sa prihláste ako moderátor.</p>
+      </div>
+    )
+  }
 
   return (
     <div className="mx-auto max-w-3xl p-6 space-y-6">

--- a/src/app/api/games/[code]/answers/route.ts
+++ b/src/app/api/games/[code]/answers/route.ts
@@ -1,9 +1,12 @@
 import { NextResponse } from 'next/server'
 import { store } from '@/lib/herdvote/store'
+import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(req: Request, context: any) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const { code } = (context?.params ?? {}) as { code: string }
   const gameCode = String(code || '').toUpperCase()
   const game = store.getGame(gameCode)

--- a/src/app/api/games/[code]/config/route.ts
+++ b/src/app/api/games/[code]/config/route.ts
@@ -1,11 +1,14 @@
 // PATH: src/app/api/games/[code]/config/route.ts
 import { NextResponse } from 'next/server'
 import { supabaseServer } from '@/integrations/supabase/server' // dôležitý import
+import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
 // (voliteľné) Načítanie aktuálnej konfigurácie hry
 export async function GET(_req: Request, context: any) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const { code } = (context?.params ?? {}) as { code: string }
 
   // Ak chceš, môžeš čítať z DB. Tu ponechám stub, aby build vždy prešiel.
@@ -25,6 +28,8 @@ export async function GET(_req: Request, context: any) {
 
 // Uloženie / update konfigurácie hry
 export async function POST(req: Request, context: any) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const { code } = (context?.params ?? {}) as { code: string }
 
   const body = await req.json().catch(() => ({} as any))

--- a/src/app/api/games/[code]/leaderboard/route.ts
+++ b/src/app/api/games/[code]/leaderboard/route.ts
@@ -1,10 +1,13 @@
 // PATH: src/app/api/games/[code]/leaderboard/route.ts
 import { NextResponse } from 'next/server'
 import { store } from '@/lib/herdvote/store'
+import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET(_req: Request, context: any) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const { code } = (context?.params ?? {}) as { code: string }
   const gameCode = String(code || '').toUpperCase()
 

--- a/src/app/api/games/[code]/lock-lobby/route.ts
+++ b/src/app/api/games/[code]/lock-lobby/route.ts
@@ -1,9 +1,12 @@
 import { NextResponse } from 'next/server'
 import { store } from '@/lib/herdvote/store'
+import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(req: Request, context: any) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   // bezpečne zoberieme route parametre
   const { code } = (context?.params ?? {}) as { code: string }
   const gameCode = String(code || '').toUpperCase()

--- a/src/app/api/games/[code]/players/route.ts
+++ b/src/app/api/games/[code]/players/route.ts
@@ -1,11 +1,14 @@
 // PATH: src/app/api/games/[code]/players/route.ts
 import { NextResponse } from 'next/server'
 import { store } from '@/lib/herdvote/store'
+import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
 // GET – vráti lobby (zoznam hráčov)
 export async function GET(_req: Request, context: any) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const { code } = (context?.params ?? {}) as { code: string }
 
   const gameCode = String(code || '').toUpperCase()
@@ -19,6 +22,8 @@ export async function GET(_req: Request, context: any) {
 
 // POST – pridá hráča (kým je lobby otvorená)
 export async function POST(req: Request, context: any) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const { code } = (context?.params ?? {}) as { code: string }
 
   const gameCode = String(code || '').toUpperCase()

--- a/src/app/api/games/[code]/rounds/[roundId]/question/route.ts
+++ b/src/app/api/games/[code]/rounds/[roundId]/question/route.ts
@@ -1,12 +1,15 @@
 // PATH: src/app/api/games/[code]/rounds/[roundId]/question/route.ts
 import { NextResponse } from 'next/server'
 import { store } from '@/lib/herdvote/store'
+import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
 type FourAnswers = { answer_a?: string; answer_b?: string; answer_c?: string; answer_d?: string }
 
 export async function GET(_req: Request, context: any) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const { code, roundId } = (context?.params ?? {}) as { code: string; roundId: string }
   const gameCode = String(code || '').toUpperCase()
 

--- a/src/app/api/games/[code]/rounds/config/route.ts
+++ b/src/app/api/games/[code]/rounds/config/route.ts
@@ -1,10 +1,13 @@
 // PATH: src/app/api/games/[code]/rounds/config/route.ts
 import { NextResponse } from 'next/server'
 import { supabaseServer } from '@/integrations/supabase/server'
+import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(req: Request, context: any) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   // Next 15 je prísny na typ 2. argumentu – použijeme voľný "context: any"
   const { code } = (context?.params ?? {}) as { code: string }
 

--- a/src/app/api/games/[code]/rounds/lock/route.ts
+++ b/src/app/api/games/[code]/rounds/lock/route.ts
@@ -3,10 +3,13 @@ import { NextResponse } from 'next/server'
 import { store } from '@/lib/herdvote/store'
 import { RealtimeServer } from '@/lib/realtime/server'
 import { channelFor } from '@/lib/realtime/types'
+import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(req: Request, context: any) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   // bezpečne vezmeme route parametre
   const { code } = (context?.params ?? {}) as { code: string }
   const gameCode = String(code || '').toUpperCase()

--- a/src/app/api/games/[code]/rounds/next/route.ts
+++ b/src/app/api/games/[code]/rounds/next/route.ts
@@ -3,10 +3,13 @@ import { NextResponse } from 'next/server'
 import { store } from '@/lib/herdvote/store'
 import { RealtimeServer } from '@/lib/realtime/server'
 import { channelFor } from '@/lib/realtime/types'
+import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(req: Request, context: any) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const { code } = (context?.params ?? {}) as { code: string }
   const gameCode = String(code || '').toUpperCase()
 

--- a/src/app/api/games/[code]/rounds/results/route.ts
+++ b/src/app/api/games/[code]/rounds/results/route.ts
@@ -4,10 +4,13 @@ import { store } from '@/lib/herdvote/store'
 import { RealtimeServer } from '@/lib/realtime/server'
 import { channelFor } from '@/lib/realtime/types'
 import { calculateRoundScores } from '@/lib/herdvote/scoring'
+import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(req: Request, context: any) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const { code } = (context?.params ?? {}) as { code: string }
   const gameCode = String(code || '').toUpperCase()
 

--- a/src/app/api/games/[code]/rounds/route.ts
+++ b/src/app/api/games/[code]/rounds/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server'
 import { store } from '@/lib/herdvote/store'
 import type { RoundSettings } from '@/lib/herdvote/store'
+import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
@@ -15,6 +16,8 @@ export const dynamic = 'force-dynamic'
  * }
  */
 export async function POST(req: Request, context: any) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const { code } = (context?.params ?? {}) as { code: string }
   const gameCode = String(code || '').toUpperCase()
 

--- a/src/app/api/games/[code]/rounds/start/route.ts
+++ b/src/app/api/games/[code]/rounds/start/route.ts
@@ -3,10 +3,13 @@ import { NextResponse } from 'next/server'
 import { store } from '@/lib/herdvote/store'
 import { RealtimeServer } from '@/lib/realtime/server'
 import { channelFor } from '@/lib/realtime/types'
+import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(req: Request, context: any) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const { code } = (context?.params ?? {}) as { code: string }
 
   const gameCode = String(code || '').toUpperCase()

--- a/src/app/api/games/[code]/rounds/timer/start/route.ts
+++ b/src/app/api/games/[code]/rounds/timer/start/route.ts
@@ -3,10 +3,13 @@ import { store } from '@/lib/herdvote/store'
 import { RealtimeServer } from '@/lib/realtime/server'
 import { channelFor } from '@/lib/realtime/types'
 import { supabaseServer } from '@/integrations/supabase/server'
+import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(req: Request, context: any) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const { code } = (context?.params ?? {}) as { code: string }
   const gameCode = String(code || '').toUpperCase()
 

--- a/src/app/api/games/[code]/route.ts
+++ b/src/app/api/games/[code]/route.ts
@@ -1,9 +1,12 @@
 import { NextResponse } from 'next/server'
 import { store } from '@/lib/herdvote/store'
+import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET(_req: Request, context: any) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const { code } = (context?.params ?? {}) as { code: string }
 
   const gameCode = String(code || '').toUpperCase()

--- a/src/app/api/games/[code]/start/route.ts
+++ b/src/app/api/games/[code]/start/route.ts
@@ -1,9 +1,12 @@
 import { NextResponse } from 'next/server'
 import { store } from '@/lib/herdvote/store'
+import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(_req: Request, context: any) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const { code } = (context?.params ?? {}) as { code: string }
 
   const gameCode = String(code || '').toUpperCase()

--- a/src/app/api/games/_session.ts
+++ b/src/app/api/games/_session.ts
@@ -1,0 +1,12 @@
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+import type { Session } from '@supabase/supabase-js'
+
+/**
+ * Returns the current user session or null if unauthenticated.
+ */
+export async function getSession(): Promise<Session | null> {
+  const supabase = createRouteHandlerClient({ cookies })
+  const { data } = await supabase.auth.getSession()
+  return data.session
+}

--- a/src/app/api/games/route.ts
+++ b/src/app/api/games/route.ts
@@ -3,10 +3,19 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { store } from '@/lib/herdvote/store';
+import { getSession } from '@/app/api/games/_session';
+
+/**
+ * Example (unauthenticated):
+ *   curl -i -X POST http://localhost:3000/api/games
+ *   -> HTTP/1.1 401 Unauthorized
+ */
 
 export const dynamic = 'force-dynamic';
 
 export async function POST(_req: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   const game = store.createGame({});
   return NextResponse.json({ gameCode: game.code });
 }


### PR DESCRIPTION
## Summary
- protect Herd Vote moderator page with useAuth and redirect unauthenticated visitors to login
- add reusable session helper and require authentication on all Herd Vote game APIs

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a63a9c64b0832781bc411f0bc62732