### PR TITLE
fix: await cookies for Next.js 15

### DIFF
--- a/src/app/api/games/_session.ts
+++ b/src/app/api/games/_session.ts
@@ -5,8 +5,9 @@ import type { Session } from '@supabase/supabase-js'
  * Returns the current user session or null if unauthenticated.
  */
 export async function getSession(): Promise<Session | null> {
+  const cookieStore = await cookies()
   const supabase = createRouteHandlerClient({
-    cookies,
+    cookies: () => cookieStore,
     options: {
       cookieOptions: {
         name: 'sb-herd-auth-token',


### PR DESCRIPTION
## Summary
- await `cookies()` before passing to Supabase client in session helper

## Testing
- `npm install` *(fails: 403 Forbidden for vitest)*
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f5e2bcb88327b16fdf31784b72d0