### PR TITLE
fix: ensure quiz login page is dynamic

### DIFF
--- a/src/app/[lang]/apps/quiz/login/page.tsx
+++ b/src/app/[lang]/apps/quiz/login/page.tsx
@@ -4,6 +4,9 @@ import { Button } from '@/components/ui/button'
 import { supabaseQuiz } from '@/lib/supabaseQuizClient'
 import { useParams } from 'next/navigation'
 
+// Ensure this route is rendered dynamically for all languages
+export const dynamic = 'force-dynamic'
+
 export default function QuizLoginPage() {
   const { lang } = useParams<{ lang: string }>()
 


### PR DESCRIPTION
## Summary
- ensure quiz moderator login page renders dynamically for all locales

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a80d175254832783d8d5c339595559