### PR TITLE
fix: ensure quiz login route is deployable

### DIFF
--- a/src/app/[lang]/apps/quiz/login/page.tsx
+++ b/src/app/[lang]/apps/quiz/login/page.tsx
@@ -4,6 +4,9 @@ import { Button } from '@/components/ui/button'
 import { supabaseQuiz } from '@/lib/supabaseQuizClient'
 import { useParams } from 'next/navigation'
 
+// Ensure this route is rendered dynamically for all languages
+export const dynamic = 'force-dynamic'
+
 export default function QuizLoginPage() {
   const { lang } = useParams<{ lang: string }>()
 

--- a/src/app/[lang]/apps/quiz/page.tsx
+++ b/src/app/[lang]/apps/quiz/page.tsx
@@ -4,6 +4,9 @@ import { type Locale, SUPPORTED_LOCALES } from '@/i18n/config'
 import { normalizeUrlLocale } from '@/lib/i18n-routing'
 import QuizPageClient from './Client'
 
+// Render quiz routes dynamically to prevent stale 404s
+export const dynamic = 'force-dynamic'
+
 type P = { params: Promise<{ lang: string }> }
 
 export default async function QuizPage({ params }: P) {


### PR DESCRIPTION
## Summary
- render quiz routes dynamically to prevent stale 404s

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a80d175254832783d8d5c339595559