### PR TITLE
feat: add auth links and theme toggle

### DIFF
--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { Brain } from 'lucide-react'
+import { supabase } from '@/lib/supabaseClient'
+
+export default function RegisterPage() {
+  const registerWithGoogle = async () => {
+    await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: { redirectTo: `${location.origin}/auth/callback` },
+    })
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
+      <div className="bg-white shadow-xl rounded-2xl p-8 text-center space-y-6 max-w-md w-full">
+        <h1 className="text-3xl font-bold flex justify-center items-center gap-2 text-purple-700">
+          <Brain className="text-pink-500" /> Zaregistruj sa a objav viac otázok
+        </h1>
+        <p className="text-gray-600">
+          Vytvor si účet a získaj každý deň nové otázky zdarma.
+        </p>
+        <Button
+          onClick={registerWithGoogle}
+          className="bg-purple-600 hover:bg-purple-700 w-full text-white"
+        >
+          Pokračovať cez Google
+        </Button>
+        <p className="text-xs text-gray-400">
+          Registrácia je bezplatná. Neposielame spam. Odhlásiš sa kedykoľvek.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/MarketingHomePage.tsx
+++ b/src/components/MarketingHomePage.tsx
@@ -87,11 +87,11 @@ export default function MarketingHomePage() {
       <section className="text-center space-y-4">
         <h2 className="text-2xl md:text-3xl font-semibold">Pripravení začať?</h2>
         <p className="text-muted-foreground">
-          Spusti bez registrácie, alebo sa prihlás a získaj 2 nové otázky denne.
+          Prihlás sa alebo sa zaregistruj a získaj 2 nové otázky denne.
         </p>
         <div className="flex items-center justify-center gap-3">
-          <Link href="/app"><Button className="h-11 px-6">Začať</Button></Link>
-          <Link href="/login"><Button variant="outline" className="h-11 px-6">Prihlásiť sa</Button></Link>
+          <Link href="/login"><Button className="h-11 px-6">Prihlásiť sa</Button></Link>
+          <Link href="/register"><Button variant="outline" className="h-11 px-6">Registrovať sa</Button></Link>
         </div>
       </section>
 

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { useI18n } from "@/components/IntlProvider"
+import ThemeToggle from "@/components/ThemeToggle"
 
 export default function SiteHeader({ lang: propLang }: { lang?: string }) {
   const { t } = useI18n()
@@ -30,7 +31,9 @@ export default function SiteHeader({ lang: propLang }: { lang?: string }) {
           ))}
         </nav>
         <div className="flex items-center gap-3">
-          <Link href={`/app`} className="text-sm underline">{t("hero.ctaTry","Spustiť hru")}</Link>
+          <Link href={`/login`} className="text-sm underline">{t("nav.login","Prihlásiť sa")}</Link>
+          <Link href={`/register`} className="text-sm underline">{t("nav.register","Registrovať sa")}</Link>
+          <ThemeToggle />
         </div>
       </div>
     </header>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Moon, Sun } from 'lucide-react'
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light')
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') as 'light' | 'dark' | null
+    const initial = stored || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+    setTheme(initial)
+    if (initial === 'dark') {
+      document.documentElement.classList.add('dark')
+    }
+  }, [])
+
+  const toggle = () => {
+    const next = theme === 'dark' ? 'light' : 'dark'
+    setTheme(next)
+    document.documentElement.classList.toggle('dark', next === 'dark')
+    localStorage.setItem('theme', next)
+  }
+
+  return (
+    <button onClick={toggle} className="p-2 rounded border">
+      {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </button>
+  )
+}

--- a/src/i18n/dictionaries/sk.json
+++ b/src/i18n/dictionaries/sk.json
@@ -6,7 +6,9 @@
     "tools": "Komunikačný kompas",
     "blog": "Blog",
     "downloads": "Downloady",
-    "apps": "Konverzačné hry"
+    "apps": "Konverzačné hry",
+    "login": "Prihlásiť sa",
+    "register": "Registrovať sa"
   },
   "aud": {
     "parentChild": "Rodič–dieťa",


### PR DESCRIPTION
## Summary
- add login, registration links, and theme switch to site header
- add register page and update home page call to action
- introduce theme toggle component for day/night mode

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a3345e708327b1eca3ae3b687cf8