### PR TITLE
Wrap auth callback with Suspense

### DIFF
--- a/src/app/auth/callback/CallbackClient.tsx
+++ b/src/app/auth/callback/CallbackClient.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { supabase } from '@/lib/supabaseClient'
+
+const ADMIN_EMAILS = ['rezvalia@gmail.com', 'jozef.bubliak@gmail.com']
+
+export default function CallbackClient() {
+  const router = useRouter()
+  const params = useSearchParams()
+
+  useEffect(() => {
+    const handleRedirect = async () => {
+      // krátka pauza, kým sa stihne vytvoriť session po návrate z OAuth
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+
+      const {
+        data: { session },
+      } = await supabase.auth.getSession()
+      const user = session?.user
+
+      console.log('[CALLBACK] Session:', session)
+      console.log('[CALLBACK] User:', user)
+
+      const next = params.get('next')
+      if (next) {
+        router.push(next)
+        return
+      }
+
+      if (user?.email && ADMIN_EMAILS.includes(user.email)) {
+        router.push('/admin')
+      } else {
+        router.push('/app')
+      }
+    }
+
+    handleRedirect()
+  }, [params, router])
+
+  return <p className="text-center p-10 text-gray-500">Prihlasovanie...</p>
+}

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,43 +1,12 @@
-'use client'
+import { Suspense } from 'react'
+import CallbackClient from './CallbackClient'
 
-import { useEffect } from 'react'
-import { useRouter, useSearchParams } from 'next/navigation'
-import { supabase } from '@/lib/supabaseClient'
+export const dynamic = 'force-dynamic'
 
-const ADMIN_EMAILS = ['rezvalia@gmail.com', 'jozef.bubliak@gmail.com']
-
-export default function AuthCallback() {
-  const router = useRouter()
-  const params = useSearchParams()
-
-  useEffect(() => {
-    const handleRedirect = async () => {
-      // krátka pauza, kým sa stihne vytvoriť session po návrate z OAuth
-      await new Promise((resolve) => setTimeout(resolve, 1000))
-
-      const {
-        data: { session },
-      } = await supabase.auth.getSession()
-      const user = session?.user
-
-      console.log('[CALLBACK] Session:', session)
-      console.log('[CALLBACK] User:', user)
-
-      const next = params.get('next')
-      if (next) {
-        router.push(next)
-        return
-      }
-
-      if (user?.email && ADMIN_EMAILS.includes(user.email)) {
-        router.push('/admin')
-      } else {
-        router.push('/app')
-      }
-    }
-
-    handleRedirect()
-  }, [params, router])
-
-  return <p className="text-center p-10 text-gray-500">Prihlasovanie...</p>
+export default function AuthCallbackPage() {
+  return (
+    <Suspense fallback={null}>
+      <CallbackClient />
+    </Suspense>
+  )
 }


### PR DESCRIPTION
## Summary
- split OAuth callback into server wrapper and client component
- wrap client callback handler in `<Suspense>` and force dynamic rendering

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: next: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a77030848327a8c81a15887f80b9