### PR TITLE
Add links to CoupleSync and Cards apps

### DIFF
--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -169,6 +169,9 @@ export default async function Page({ params }: P) {
             <Link href={go('/apps/spoznajme-sa')} className="rounded-md border px-4 py-2 text-sm">
               {t('Spustiť „Spoznajme sa“', 'Start “Get to know us”')}
             </Link>
+            <Link href={go('/apps/couplesync')} className="rounded-md border px-4 py-2 text-sm">
+              {t('Spustiť CoupleSync', 'Start CoupleSync')}
+            </Link>
           </div>
         </div>
       </section>

--- a/src/components/MarketingHomePage.tsx
+++ b/src/components/MarketingHomePage.tsx
@@ -47,15 +47,19 @@ export default function MarketingHomePage() {
                 Premyslené otázky, ktoré pomáhajú partnerom, priateľom a rodinám komunikovať zmysluplne, 
                 budovať dôveru a vytvárať skutočné spojenie.
               </p>
-              <div className="flex flex-col sm:flex-row gap-4">
-                <Button variant="hero" size="xl" className="group">
-                  Začať hneď
-                  <ArrowRight className="ml-2 h-5 w-5 transition-transform group-hover:translate-x-1" />
-                </Button>
-                <Button variant="glass" size="xl">
-                  Vyskúšať zdarma
-                </Button>
-              </div>
+                <div className="flex flex-col sm:flex-row gap-4">
+                  <Button asChild variant="hero" size="xl" className="group">
+                    <Link href="/sk/apps/couplesync" aria-label="CoupleSync dotazník">
+                      CoupleSync
+                      <ArrowRight className="ml-2 h-5 w-5 transition-transform group-hover:translate-x-1" />
+                    </Link>
+                  </Button>
+                  <Button asChild variant="glass" size="xl">
+                    <Link href="/sk/apps/spoznajme-sa" aria-label="Kartičky Spoznajme sa">
+                      Kartičky
+                    </Link>
+                  </Button>
+                </div>
             </div>
 
             <div className="relative animate-slide-up">


### PR DESCRIPTION
## Summary
- Link marketing homepage directly to CoupleSync questionnaire and Kartičky game
- Expose CoupleSync CTA on localized landing page for quick access

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8aac9a2e08327bb88258aa0969ae8