### PR TITLE
fix: unify spoznajme sa game routes

### DIFF
--- a/src/app/[lang]/apps/cards/page.tsx
+++ b/src/app/[lang]/apps/cards/page.tsx
@@ -1,52 +1,11 @@
-import Image from 'next/image'
-import Link from 'next/link'
-import { notFound } from 'next/navigation'
-import { getDictionary } from '@/i18n/server'
-import { type Locale, SUPPORTED_LOCALES } from '@/i18n/config'
+import { notFound, redirect } from 'next/navigation'
 import { normalizeUrlLocale } from '@/lib/i18n-routing'
-import { Button } from '@/components/ui/button'
+import { type Locale, SUPPORTED_LOCALES } from '@/i18n/config'
 
-type P = { params: Promise<{ lang: string }> }
-
-export default async function CardsPage({ params }: P) {
+// Redirect legacy /apps/cards to /apps/spoznajme-sa
+export default async function Page({ params }: { params: Promise<{ lang: string }> }) {
   const { lang: raw } = await params
   const lang = normalizeUrlLocale(raw)
   if (!SUPPORTED_LOCALES.includes(lang as Locale)) notFound()
-  const dict = await getDictionary(lang as Locale)
-  const game = dict.apps.games.cards
-  const back = dict.apps.games.ctaBack
-
-  return (
-    <div className="space-y-8">
-      <div className="text-center space-y-4">
-        <h1 className="text-4xl font-bold">{game.name}</h1>
-        <p className="text-lg text-muted-foreground">{game.description}</p>
-        <Image
-          src="/images/placeholder.jpg"
-          alt=""
-          width={600}
-          height={300}
-          className="mx-auto rounded-lg"
-        />
-        <Button asChild size="lg" className="mt-4">
-          <Link href={`/${lang}${game.link}`}>{game.cta}</Link>
-        </Button>
-      </div>
-
-      <section className="mx-auto max-w-xl space-y-4">
-        <h2 className="text-2xl font-semibold text-center">Ako to funguje</h2>
-        <ol className="list-decimal list-inside space-y-2 text-left">
-          {game.manual.map((step: string, i: number) => (
-            <li key={i}>{step}</li>
-          ))}
-        </ol>
-      </section>
-
-      <div className="text-center">
-        <Button variant="link" asChild>
-          <Link href={`/${lang}/apps`}>{back}</Link>
-        </Button>
-      </div>
-    </div>
-  )
+  redirect(`/${lang}/apps/spoznajme-sa`)
 }

--- a/src/app/[lang]/apps/page.tsx
+++ b/src/app/[lang]/apps/page.tsx
@@ -18,7 +18,7 @@ export default async function AppsPage({ params }: P) {
   const games = apps.games
   const categories = [
     { key: 'quizzes', slugs: ['quiz'] },
-    { key: 'cards', slugs: ['cards'] },
+    { key: 'cards', slugs: ['spoznajme-sa'] },
     { key: 'puzzles', slugs: ['hadacka'] },
     { key: 'surveys', slugs: ['couplesync'] },
   ]

--- a/src/i18n/dictionaries/en.json
+++ b/src/i18n/dictionaries/en.json
@@ -72,7 +72,7 @@
           "Compare who matches best"
         ]
       },
-      "cards": {
+      "spoznajme-sa": {
         "name": "Conversation cards",
         "description": "Conversations that bring you closer. Cards full of questions to get to know partner, friends or family.",
         "cta": "Pick cards",

--- a/src/i18n/dictionaries/sk.json
+++ b/src/i18n/dictionaries/sk.json
@@ -74,7 +74,7 @@
           "Porovnajte, kto sa pozná najlepšie"
         ]
       },
-      "cards": {
+      "spoznajme-sa": {
         "name": "Konverzačné kartičky",
         "description": "Rozhovory, ktoré vás zblížia. Kartičky plné otázok na hlbšie spoznanie partnera, kamarátov, rodiny.",
         "cta": "Vybrať kartičky",


### PR DESCRIPTION
## Summary
- link card game slug to `/apps/spoznajme-sa`
- redirect legacy `/apps/cards` to the new slug
- update translation dictionaries for the new slug

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b2e83aec8327a055e46e0eafa93a