### PR TITLE
feat: expand couplesync intro page

### DIFF
--- a/src/app/[lang]/apps/couplesync/Client.tsx
+++ b/src/app/[lang]/apps/couplesync/Client.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+
+type Props = { dict: any; lang: string }
+
+function MagicLinkButton({ lang, label }: { lang: string; label: string }) {
+  const router = useRouter()
+  const handleClick = () => {
+    const chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    const array = new Uint8Array(22)
+    crypto.getRandomValues(array)
+    let token = ''
+    array.forEach((n) => (token += chars[n % chars.length]))
+    router.push(`/${lang}/apps/couplesync/start?room=${token}`)
+  }
+  return (
+    <Button onClick={handleClick} size="lg">
+      {label}
+    </Button>
+  )
+}
+
+export default function Client({ dict, lang }: Props) {
+  const cs = dict.apps.games.couplesync
+  const back = dict.apps.games.ctaBack
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-10 space-y-16">
+      <Link
+        href={`/${lang}/apps`}
+        className="text-sm text-muted-foreground hover:underline"
+      >
+        ← {back}
+      </Link>
+
+      <section className="text-center space-y-4">
+        <h1 className="text-4xl font-bold">{cs.heroTitle}</h1>
+        <p className="text-lg text-muted-foreground">{cs.heroSubtitle}</p>
+        <div className="flex flex-col sm:flex-row gap-4 justify-center pt-2">
+          <Button asChild size="lg">
+            <Link href={`/auth/login?next=/${lang}/apps/couplesync/start`}>
+              {cs.ctaEmail}
+            </Link>
+          </Button>
+          <MagicLinkButton lang={lang} label={cs.ctaMagic} />
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <h2 className="text-2xl font-semibold text-center">{cs.whyTitle}</h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {cs.whyPoints.map((p: string, i: number) => (
+            <div key={i} className="rounded-xl border p-4 text-sm text-left">
+              {p}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold text-center">{cs.benefitsTitle}</h2>
+        <ul className="space-y-2 text-center">
+          {cs.benefitsList.map((b: string, i: number) => (
+            <li key={i}>{b}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold text-center">{cs.barriersTitle}</h2>
+        <div className="grid gap-4 sm:grid-cols-3">
+          {cs.barriersCards.map((b: string, i: number) => (
+            <div key={i} className="rounded-xl border p-5 text-center text-sm">
+              {b}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold text-center">{cs.howTitle}</h2>
+        <ol className="list-decimal list-inside space-y-2 max-w-xl mx-auto text-left">
+          {cs.howSteps.map((s: string, i: number) => (
+            <li key={i}>{s}</li>
+          ))}
+        </ol>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold text-center">{cs.privacyTitle}</h2>
+        <ul className="space-y-2 max-w-xl mx-auto text-left">
+          {cs.privacyPoints.map((p: string, i: number) => (
+            <li key={i} className="flex gap-2">
+              <span>✓</span>
+              <span>{p}</span>
+            </li>
+          ))}
+        </ul>
+        <p className="text-center text-sm pt-2">
+          <Link href="/privacy" className="underline">
+            Privacy
+          </Link>
+        </p>
+      </section>
+
+      <footer className="text-center text-sm text-muted-foreground pt-4">
+        {cs.footerNotice}
+      </footer>
+    </div>
+  )
+}
+

--- a/src/app/[lang]/apps/couplesync/page.tsx
+++ b/src/app/[lang]/apps/couplesync/page.tsx
@@ -1,8 +1,8 @@
-import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { getDictionary } from '@/i18n/server'
 import { type Locale, SUPPORTED_LOCALES } from '@/i18n/config'
 import { normalizeUrlLocale } from '@/lib/i18n-routing'
+import Client from './Client'
 
 type P = { params: Promise<{ lang: string }> }
 
@@ -17,47 +17,6 @@ export default async function Page({ params }: P) {
   const lang = normalizeUrlLocale(raw)
   if (!SUPPORTED_LOCALES.includes(lang as Locale)) notFound()
   const dict = await getDictionary(lang as Locale)
-  const game = dict.apps.games.couplesync
-  const back = dict.apps.games.ctaBack
-  const how = dict.apps.games.how
-
-  return (
-    <div className="mx-auto max-w-6xl px-4 py-10 space-y-10">
-      <Link
-        href={`/${lang}/apps`}
-        className="text-sm text-muted-foreground hover:underline"
-      >
-        ← {back}
-      </Link>
-
-      <header className="space-y-3 text-center md:text-left">
-        <h1 className="text-3xl font-semibold tracking-tight">{game.name}</h1>
-        <p className="text-muted-foreground max-w-2xl mx-auto md:mx-0">
-          {game.description}
-        </p>
-        <div className="flex gap-3 pt-1 justify-center md:justify-start">
-          <Link
-            href={game.link}
-            className="px-4 py-2 rounded-md bg-black text-white text-sm"
-          >
-            {game.cta}
-          </Link>
-          <a
-            href="#how"
-            className="px-4 py-2 rounded-md border text-sm"
-          >
-            {how}
-          </a>
-        </div>
-      </header>
-
-      <section id="how" className="grid md:grid-cols-3 gap-6">
-        {game.manual.map((step: string, i: number) => (
-          <div key={i} className="rounded-xl border p-5">
-            <h3 className="font-medium">{i + 1}. {step}</h3>
-          </div>
-        ))}
-      </section>
-    </div>
-  )
+  return <Client dict={dict} lang={lang} />
 }
+

--- a/src/i18n/dictionaries/en.json
+++ b/src/i18n/dictionaries/en.json
@@ -103,7 +103,40 @@
           "Answer honestly",
           "Compare results",
           "Discuss together"
-        ]
+        ],
+        "heroTitle": "CoupleSync",
+        "heroSubtitle": "A safe, two-partner questionnaire to map what you want, don't want, and where you match — from daily rituals to intimate preferences (18+).",
+        "ctaEmail": "Sign in with email",
+        "ctaMagic": "Create private room (magic link)",
+        "whyTitle": "Why this questionnaire matters",
+        "whyPoints": [
+          "Only ~62% are satisfied with their love/sex life (≈ 38% are not).",
+          "Partners know roughly ~62% of what the other likes and ~26% of what they dislike.",
+          "When issues exist, full honesty is rare – fewer than 25% of couples say they're always honest.",
+          "About 14–15% of marriages are 'sexless' (≤10×/year)."
+        ],
+        "benefitsTitle": "What CoupleSync gives you",
+        "benefitsList": [
+          "Map of matches and differences",
+          "No shame, no pressure",
+          "Results you can talk about"
+        ],
+        "barriersTitle": "What usually blocks intimacy",
+        "barriersCards": ["Stress and fatigue", "Desire discrepancy", "Postpartum / health periods"],
+        "howTitle": "How it works",
+        "howSteps": [
+          "Create a private room",
+          "Each answers on their own",
+          "Shared overview with respect for boundaries"
+        ],
+        "privacyTitle": "Privacy & Security",
+        "privacyPoints": [
+          "No names or required profiles",
+          "Private room via unguessable link",
+          "Option to use email or not",
+          "Delete with one click"
+        ],
+        "footerNotice": "Content intended for 18+ only"
       },
       "ctaBack": "Want to try another game?",
       "how": "How it works"

--- a/src/i18n/dictionaries/sk.json
+++ b/src/i18n/dictionaries/sk.json
@@ -105,7 +105,40 @@
           "Odpovedajte úprimne",
           "Porovnajte výsledky",
           "Porozprávajte sa spolu"
-        ]
+        ],
+        "heroTitle": "CoupleSync",
+        "heroSubtitle": "Bezpečný dvoj-dotazník, ktorý vám pomôže zistiť, čo chcete, čo nechcete a na čom sa viete zhodnúť – od bežných rituálov až po intímne preferencie (18+).",
+        "ctaEmail": "Prihlásiť e-mailom",
+        "ctaMagic": "Vytvoriť súkromnú miestnosť (magic link)",
+        "whyTitle": "Prečo tento dotazník existuje",
+        "whyPoints": [
+          "Globálne je s milostným/sexuálnym životom spokojných len ~62 % ľudí (≈ 38 % nie).",
+          "Partneri poznajú v priemere ~62 % toho, čo má druhý rád, a ~26 % toho, čo mu nevyhovuje.",
+          "Pri už existujúcich ťažkostiach je úplná úprimnosť zriedkavá – < 25 % párov tvrdí, že sú vždy úprimní.",
+          "~14–15 % manželstiev je „sexless“ (≤ 10×/rok)."
+        ],
+        "benefitsTitle": "Čo vám CoupleSync prinesie",
+        "benefitsList": [
+          "Mapa zhôd a rozdielov",
+          "Bez hanby, bez nátlaku",
+          "Výsledky, o ktorých sa dá rozprávať"
+        ],
+        "barriersTitle": "Čo typicky brzdí intimitu",
+        "barriersCards": ["Stres a únava", "Rozdiel v túžbe", "Obdobia po pôrode / zdravie"],
+        "howTitle": "Ako to funguje",
+        "howSteps": [
+          "Vytvoríte súkromnú miestnosť",
+          "Každý odpovedá sám za seba",
+          "Spoločný prehľad s rešpektom k hraniciam"
+        ],
+        "privacyTitle": "Súkromie a bezpečnosť",
+        "privacyPoints": [
+          "Žiadne mená ani povinné profily",
+          "Súkromná miestnosť cez neuhádnuteľný odkaz",
+          "Možnosť použiť e-mail (pohodlie) alebo nie",
+          "Vymazanie jedným klikom"
+        ],
+        "footerNotice": "Obsah určený len pre 18+"
       },
       "ctaBack": "Chcem skúsiť inú hru",
       "how": "Ako to funguje"


### PR DESCRIPTION
## Summary
- build full landing page for CoupleSync with hero, facts, benefits, barriers, steps, and privacy sections
- add magic-link generation and email login CTA
- extend i18n dictionaries with translations for new sections

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a8cd31b554832798aeb638ee757096