### PR TITLE
Fix login link and add auth page

### DIFF
--- a/src/app/(unauth)/landing/page.tsx
+++ b/src/app/(unauth)/landing/page.tsx
@@ -36,7 +36,7 @@ export default function HomePage() {
           <Button
             variant="outline"
             className="w-full"
-            onClick={() => router.push('/auth')}
+            onClick={() => router.push('/auth/login')}
           >
             Prihlásiť sa a získať 2 otázky denne
           </Button>

--- a/src/app/[lang]/apps/herd-vote/page.tsx
+++ b/src/app/[lang]/apps/herd-vote/page.tsx
@@ -25,7 +25,7 @@ export default function HerdVoteAdminPage() {
   const router = useRouter()
   const { user, loading } = useAuth()
   useEffect(() => {
-    if (!loading && !user) router.replace(`/auth?next=/${lang}/apps/herd-vote`)
+    if (!loading && !user) router.replace(`/auth/login?next=/${lang}/apps/herd-vote`)
   }, [loading, user, router, lang])
 
   const [gameCode, setGameCode] = useState<string>('')
@@ -200,7 +200,7 @@ export default function HerdVoteAdminPage() {
         <p className="mb-4">Na spustenie hry sa prihláste ako moderátor.</p>
         <a
           className="text-blue-600 underline"
-          href={`/auth?next=/${lang}/apps/herd-vote`}
+          href={`/auth/login?next=/${lang}/apps/herd-vote`}
         >
           Prihlásiť sa
         </a>

--- a/src/app/[lang]/apps/quiz/Client.tsx
+++ b/src/app/[lang]/apps/quiz/Client.tsx
@@ -35,7 +35,7 @@ export default function QuizPageClient({ dict, lang }: Props) {
           {user ? (
             <Link href={`/${lang}${game.link}`}>{game.cta}</Link>
           ) : (
-            <Link href={`/auth?next=/${lang}/apps/quiz`}>
+            <Link href={`/auth/login?next=/${lang}/apps/quiz`}>
               Prihlásiť sa ako moderátor
             </Link>
           )}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -47,7 +47,7 @@ export default function AdminPage() {
 
       const user = session?.user
       if (!user) {
-        router.replace('/auth')
+        router.replace('/auth/login')
       } else if (!user.email || !ADMIN_EMAILS.includes(user.email)) {
         router.replace('/')
       } else {

--- a/src/app/apps/hadacka/moderator/page.tsx
+++ b/src/app/apps/hadacka/moderator/page.tsx
@@ -21,7 +21,7 @@ export default function ModeratorPage() {
 
   useEffect(() => {
     if (!loading && !user) {
-      router.replace('/auth')
+      router.replace('/auth/login')
     }
   }, [user, loading, router])
 

--- a/src/app/apps/hadacka/page.tsx
+++ b/src/app/apps/hadacka/page.tsx
@@ -29,7 +29,7 @@ export default function HadackaLandingPage() {
               </>
             ) : (
               <Button asChild size="sm">
-                <Link href="/auth">Prihlásiť sa</Link>
+                <Link href="/auth/login">Prihlásiť sa</Link>
               </Button>
             )}
           </div>
@@ -64,7 +64,7 @@ export default function HadackaLandingPage() {
               </Button>
             ) : (
               <Button asChild size="lg" className="btn-primary">
-                <Link href="/auth">Prihlásiť sa ako moderátor</Link>
+                <Link href="/auth/login">Prihlásiť sa ako moderátor</Link>
               </Button>
             )}
             <Button asChild variant="outline" size="lg">

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { useState, FormEvent } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { supabase } from '@/lib/supabaseClient'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+export default function LoginPage() {
+  const params = useSearchParams()
+  const next = params.get('next') || '/app'
+
+  const [email, setEmail] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [sent, setSent] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleLogin = async (e: FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setError(null)
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        emailRedirectTo: `${location.origin}/auth/callback?next=${encodeURIComponent(next)}`,
+      },
+    })
+    if (error) {
+      setError(error.message)
+    } else {
+      setSent(true)
+    }
+    setLoading(false)
+  }
+
+  if (sent) {
+    return (
+      <div className="max-w-sm mx-auto py-10">
+        <p className="text-center text-sm text-muted-foreground">
+          Odkaz na prihlásenie bol odoslaný na {email}. Skontrolujte svoj e‑mail.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen p-4">
+      <form onSubmit={handleLogin} className="space-y-4 w-full max-w-sm">
+        <Input
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="vam@example.com"
+        />
+        <Button type="submit" disabled={loading} className="w-full">
+          {loading ? 'Odosielam…' : 'Prihlásiť e‑mailom'}
+        </Button>
+        {error && (
+          <p className="text-sm text-destructive text-center">{error}</p>
+        )}
+      </form>
+    </div>
+  )
+}

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation'
+
+export default function AuthIndex({ searchParams }: { searchParams?: { next?: string } }) {
+  const next = searchParams?.next ? `?next=${encodeURIComponent(searchParams.next)}` : ''
+  redirect(`/auth/login${next}`)
+}

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -29,7 +29,7 @@ export default function FavoritesPage() {
     const getUser = async () => {
       const { data } = await supabase.auth.getUser()
       if (!data.user) {
-        router.push('/auth')
+        router.push('/auth/login')
       } else {
         setUser(data.user)
         fetchFavorites(mockFavoriteIds)

--- a/src/app/free/page.tsx
+++ b/src/app/free/page.tsx
@@ -137,7 +137,7 @@ export default function FreePage() {
                     <Share2 size={16} /> Skopírovať otázku
                   </button>
                   <button
-                    onClick={() => router.push('/auth')}
+                    onClick={() => router.push('/auth/login')}
                     className="text-gray-500 hover:text-gray-700 flex items-center gap-1"
                   >
                     <Heart size={16} /> Označiť ako obľúbenú
@@ -166,7 +166,7 @@ export default function FreePage() {
                     Iná skupina
                   </Button>
                   <Button
-                    onClick={() => router.push('/auth')}
+                    onClick={() => router.push('/auth/login')}
                     className="bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700"
                   >
                     Prihlásiť sa zdarma

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -29,7 +29,7 @@ export default function HistoryPage() {
     const getUser = async () => {
       const { data } = await supabase.auth.getUser()
       if (!data.user) {
-        router.push('/auth')
+        router.push('/auth/login')
       } else {
         setUser(data.user)
         fetchHistory(mockHistoryIds)

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -6,5 +6,5 @@ export default async function Page({
   searchParams: Promise<{ next?: string }>
 }) {
   const { next } = await searchParams
-  redirect(`/auth${next ? `?next=${encodeURIComponent(next)}` : ''}`)
+  redirect(`/auth/login${next ? `?next=${encodeURIComponent(next)}` : ''}`)
 }

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -6,5 +6,5 @@ export default async function Page({
   searchParams: Promise<{ next?: string }>
 }) {
   const { next } = await searchParams
-  redirect(`/auth${next ? `?next=${encodeURIComponent(next)}` : ''}`)
+  redirect(`/auth/login${next ? `?next=${encodeURIComponent(next)}` : ''}`)
 }

--- a/src/components/GroupCompletionContent.tsx
+++ b/src/components/GroupCompletionContent.tsx
@@ -151,7 +151,7 @@ export default function GroupCompletionContent({
 
           {!user && (
             <Button
-              onClick={() => router.push('/auth')}
+              onClick={() => router.push('/auth/login')}
               className="bg-gray-100 text-gray-800 hover:bg-gray-200 h-12"
             >
               ✍️ Registrovať sa a získať 2 otázky denne

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -79,7 +79,7 @@ export default function Layout({ children }: LayoutProps) {
                 </div>
               ) : (
                 <div className="flex gap-2">
-                  <Button variant="outline" onClick={() => router.push('/auth')}>
+                  <Button variant="outline" onClick={() => router.push('/auth/login')}>
                     Prihlásenie
                   </Button>
                   <Button onClick={() => router.push('/upgrade')}>Plný prístup</Button>
@@ -136,7 +136,7 @@ export default function Layout({ children }: LayoutProps) {
                     <Button
                       variant="outline"
                       onClick={() => {
-                        router.push('/auth')
+                        router.push('/auth/login')
                         setMobileMenuOpen(false)
                       }}
                       className="w-full"

--- a/src/components/LegacyApp.tsx
+++ b/src/components/LegacyApp.tsx
@@ -154,7 +154,7 @@ const router = useRouter()
   const handleFavoritesToggle = () => {
     if (!user) {
       alert('Pre obľúbené otázky sa musíš prihlásiť!')
-      router.push('/auth')
+      router.push('/auth/login')
       return
     }
     setFavoritesMode(!favoritesMode)
@@ -262,7 +262,7 @@ const router = useRouter()
                       variant="outline"
                       size="sm"
                       className="mt-2"
-                      onClick={() => router.push('/auth')}
+                      onClick={() => router.push('/auth/login')}
                     >
                       Prihlásiť sa
                     </Button>
@@ -331,7 +331,7 @@ const router = useRouter()
                         variant="link"
                         size="sm"
                         className="text-yellow-800 underline px-1"
-                        onClick={() => router.push('/auth')}
+                        onClick={() => router.push('/auth/login')}
                       >
                         prihlás
                       </Button>

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -31,7 +31,7 @@ export default function SiteHeader({ lang: propLang }: { lang?: string }) {
           ))}
         </nav>
         <div className="flex items-center gap-3">
-          <Link href={`/auth`} className="text-sm underline">{t("nav.login","Prihlásiť sa")}</Link>
+          <Link href={`/auth/login`} className="text-sm underline">{t("nav.login","Prihlásiť sa")}</Link>
           <ThemeToggle />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add `/auth/login` page with email login via Supabase
- redirect `/auth` to the new login page and update links

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cfadd92883279bf41f47c865d9be