### PR TITLE
Wrap login search params in Suspense

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,12 +1,12 @@
 'use client'
 
-import { useState, FormEvent } from 'react'
+import { useState, FormEvent, Suspense } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { supabase } from '@/lib/supabaseClient'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 
-export default function LoginPage() {
+function LoginPageContent() {
   const params = useSearchParams()
   const next = params.get('next') || '/app'
 
@@ -61,5 +61,13 @@ export default function LoginPage() {
         )}
       </form>
     </div>
+  )
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={null}>
+      <LoginPageContent />
+    </Suspense>
   )
 }


### PR DESCRIPTION
## Summary
- wrap auth login page with Suspense boundary to satisfy Next.js `useSearchParams` requirements

## Testing
- `npm test` *(fails: vitest not found)*
- `npm ci` *(fails: 403 Forbidden - cannot install vitest)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d366427c832795fc2c9f73e7160d