### PR TITLE
refactor: move conversation cards under apps namespace

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,10 +7,18 @@ const nextConfig: NextConfig = {
   async redirects() {
     const r: { source: string; destination: string; permanent: boolean }[] = []
     for (const l of SUP) {
-      r.push({ source: `/${l}/pomocky`,    destination: `/${l}/kompas`, permanent: true })
+      r.push({ source: `/${l}/pomocky`, destination: `/${l}/kompas`, permanent: true })
     }
     r.push({ source: `/pomocky`, destination: `/sk/kompas`, permanent: true })
+
+    // legacy app route redirects
+    r.push({ source: `/app`, destination: `/sk/apps/spoznajme-sa/play`, permanent: true })
+    r.push({ source: `/app/:path*`, destination: `/sk/apps/spoznajme-sa/play`, permanent: true })
+    r.push({ source: `/apps`, destination: `/sk/apps`, permanent: true })
+    r.push({ source: `/play`, destination: `/sk/apps/spoznajme-sa/play`, permanent: true })
+
     return r
   },
 }
+
 export default nextConfig

--- a/src/app/[lang]/apps/spoznajme-sa/page.tsx
+++ b/src/app/[lang]/apps/spoznajme-sa/page.tsx
@@ -26,7 +26,10 @@ export default async function Page({ params }: P) {
           Vždy bezpečné – s preskočením a bez citlivých tém.
         </p>
         <div className="flex gap-3 pt-1">
-          <Link href="/app" className="px-4 py-2 rounded-md bg-black text-white text-sm">
+          <Link
+            href={`/${lang}/apps/spoznajme-sa/play`}
+            className="px-4 py-2 rounded-md bg-black text-white text-sm"
+          >
             Spustiť hru
           </Link>
           <a href="#packs" className="px-4 py-2 rounded-md border text-sm">

--- a/src/app/[lang]/apps/spoznajme-sa/play/page.tsx
+++ b/src/app/[lang]/apps/spoznajme-sa/play/page.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { Suspense } from 'react'
+import LegacyApp from '@/components/LegacyApp'
+
+export const dynamic = 'force-dynamic'
+
+export default function Page() {
+  return (
+    <Suspense fallback={null}>
+      <LegacyApp />
+    </Suspense>
+  )
+}

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -1,7 +1,0 @@
-﻿'use client';
-
-import LegacyApp from '@/components/LegacyApp';
-
-export default function AppPage() {
-  return <LegacyApp />;
-}

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -7,7 +7,9 @@ import { supabase } from '@/lib/supabaseClient'
 export default function AuthCallbackPage() {
   const router = useRouter()
   const params = useSearchParams()
-  const next = params.get('next') && params.get('next')!.startsWith('/') ? params.get('next')! : '/app'
+  const next = params.get('next') && params.get('next')!.startsWith('/')
+    ? params.get('next')!
+    : '/sk/apps/spoznajme-sa/play'
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -8,8 +8,8 @@ import { Button } from '@/components/ui/button'
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card'
 
 function safeNext(next: string | null) {
-  // povolíme len interné cesty typu /app, /xyz atď.
-  if (!next || !next.startsWith('/')) return '/app'
+  // povolíme len interné cesty typu /xyz atď.
+  if (!next || !next.startsWith('/')) return '/sk/apps/spoznajme-sa/play'
   return next
 }
 
@@ -90,7 +90,9 @@ function AuthPageContent() {
         <CardHeader>
           <CardTitle>Vstup do súkromnej miestnosti</CardTitle>
           <CardDescription>Nepoužívame heslá – prihlásenie cez Google alebo magický odkaz.</CardDescription>
-          {next !== '/app' && <CardDescription>Táto sekcia vyžaduje prihlásenie.</CardDescription>}
+          {next !== '/sk/apps/spoznajme-sa/play' && (
+            <CardDescription>Táto sekcia vyžaduje prihlásenie.</CardDescription>
+          )}
         </CardHeader>
 
         <CardContent className="space-y-4">

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -58,7 +58,10 @@ export default function FavoritesPage() {
           </ul>
         )}
 
-        <Button variant="outline" onClick={() => router.push('/app')}>
+        <Button
+          variant="outline"
+          onClick={() => router.push('/sk/apps/spoznajme-sa/play')}
+        >
           Naspäť do aplikácie
         </Button>
       </div>

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -58,7 +58,10 @@ export default function HistoryPage() {
           </ul>
         )}
 
-        <Button variant="outline" onClick={() => router.push('/app')}>
+        <Button
+          variant="outline"
+          onClick={() => router.push('/sk/apps/spoznajme-sa/play')}
+        >
           Naspäť do aplikácie
         </Button>
       </div>

--- a/src/app/thank-you/page.tsx
+++ b/src/app/thank-you/page.tsx
@@ -17,7 +17,10 @@ export default function ThankYouPage() {
         <p className="text-gray-700">
           Tvoja plná verzia je aktívna. Môžeš teraz využívať všetky otázky a funkcie bez obmedzení.
         </p>
-        <Button onClick={() => router.push('/app')} className="mt-4 w-full">
+        <Button
+          onClick={() => router.push('/sk/apps/spoznajme-sa/play')}
+          className="mt-4 w-full"
+        >
           Pokračovať do aplikácie
         </Button>
       </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -23,7 +23,7 @@ export default function Layout({ children }: LayoutProps) {
 
   const menuItems: MenuItem[] = [
     { path: '/', label: 'Domov', icon: Brain },
-    { path: '/app', label: 'Otázky', icon: Brain },
+    { path: '/sk/apps/spoznajme-sa/play', label: 'Otázky', icon: Brain },
     ...(user
       ? [
           { path: '/favorites', label: 'Obľúbené', icon: Heart },

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -20,7 +20,7 @@ export default function Hero({ lang }: { lang: string }) {
         </p>
         <div className="flex gap-3">
           <Link href={`/${lang}/kompas`}><Button size="lg">{t("hero.ctaStart","Otvoriť kompas")}</Button></Link>
-          <Link href={`/app`}><Button size="lg" variant="outline">{t("hero.ctaTry","Spustiť hru")}</Button></Link>
+          <Link href={`/${lang}/apps/spoznajme-sa/play`}><Button size="lg" variant="outline">{t("hero.ctaTry","Spustiť hru")}</Button></Link>
         </div>
       </div>
       <div className="rounded-xl border p-5 shadow-sm bg-background">

--- a/src/i18n/dictionaries/en.json
+++ b/src/i18n/dictionaries/en.json
@@ -76,7 +76,7 @@
         "name": "Conversation cards",
         "description": "Conversations that bring you closer. Cards full of questions to get to know partner, friends or family.",
         "cta": "Pick cards",
-        "link": "/app",
+        "link": "/apps/spoznajme-sa",
         "manual": [
           "Choose a deck",
           "Draw a card",

--- a/src/i18n/dictionaries/sk.json
+++ b/src/i18n/dictionaries/sk.json
@@ -78,7 +78,7 @@
         "name": "Konverzačné kartičky",
         "description": "Rozhovory, ktoré vás zblížia. Kartičky plné otázok na hlbšie spoznanie partnera, kamarátov, rodiny.",
         "cta": "Vybrať kartičky",
-        "link": "/app",
+        "link": "/apps/spoznajme-sa",
         "manual": [
           "Vyberte balíček",
           "Potiahnite kartičku",


### PR DESCRIPTION
## Summary
- add redirects for legacy `/app` paths
- serve conversation cards at `/sk/apps/spoznajme-sa/play`
- update navigation, auth, and links to point at new location

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e5efca808327a9eb0f16f6352fe0