### PR TITLE
Fix login redirect and persist user session in header

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,6 +1,11 @@
 import { redirect } from 'next/navigation'
 
-export default function Page({ searchParams }: { searchParams: { next?: string } }) {
-  const next = searchParams?.next ? `?next=${encodeURIComponent(searchParams.next)}` : ''
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ next?: string }>
+}) {
+  const params = await searchParams
+  const next = params?.next ? `?next=${encodeURIComponent(params.next)}` : ''
   redirect(`/auth${next}`)
 }

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -1,6 +1,11 @@
 import { redirect } from 'next/navigation'
 
-export default function Page({ searchParams }: { searchParams: { next?: string } }) {
-  const next = searchParams?.next ? `?next=${encodeURIComponent(searchParams.next)}` : ''
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ next?: string }>
+}) {
+  const params = await searchParams
+  const next = params?.next ? `?next=${encodeURIComponent(params.next)}` : ''
   redirect(`/auth${next}`)
 }

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,13 +1,18 @@
 "use client"
 
 import Link from "next/link"
-import { usePathname } from "next/navigation"
+import { usePathname, useSearchParams } from "next/navigation"
 import { useI18n } from "@/components/IntlProvider"
 import ThemeToggle from "@/components/ThemeToggle"
+import { useAuth } from "@/hooks/useAuth"
 
 export default function SiteHeader({ lang: propLang }: { lang?: string }) {
   const { t } = useI18n()
   const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const currentPath =
+    pathname + (searchParams?.toString() ? `?${searchParams.toString()}` : "")
+  const { user, signOut } = useAuth()
   const l = propLang || (pathname ? (pathname.split("/")[1] || "sk") : "sk")
 
   const items = [
@@ -31,7 +36,18 @@ export default function SiteHeader({ lang: propLang }: { lang?: string }) {
           ))}
         </nav>
         <div className="flex items-center gap-3">
-          <Link href={`/auth/login`} className="text-sm underline">{t("nav.login","Prihlásiť sa")}</Link>
+          {user ? (
+            <button onClick={signOut} className="text-sm underline">
+              {t("nav.logout", "Odhlásiť sa")}
+            </button>
+          ) : (
+            <Link
+              href={`/auth/login?next=${encodeURIComponent(currentPath)}`}
+              className="text-sm underline"
+            >
+              {t("nav.login", "Prihlásiť sa")}
+            </Link>
+          )}
           <ThemeToggle />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- keep login URL from redirecting to /app unnecessarily
- show logged-in state and preserve current path when logging in
- handle promised search params on registration redirect

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e8b51fa883278d6f7f68d8633a1d