### PR TITLE
Use Supabase to lock lobby

### DIFF
--- a/src/app/api/games/[code]/lock-lobby/route.ts
+++ b/src/app/api/games/[code]/lock-lobby/route.ts
@@ -1,30 +1,55 @@
 import { NextResponse } from 'next/server'
-import { store } from '@/lib/herdvote/store'
 import { getSession } from '@/app/api/games/_session'
+import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
-export async function POST(req: Request, context: any) {
+export async function POST(_req: Request, context: any) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  // bezpečne zoberieme route parametre
+
   const { code } = (context?.params ?? {}) as { code: string }
   const gameCode = String(code || '').toUpperCase()
 
-  const game = store.getGame(gameCode)
-  if (!game) {
+  const supabase = supabaseServer(session.access_token)
+
+  const { data: room } = await supabase
+    .from('rooms')
+    .select('id')
+    .eq('code', gameCode)
+    .eq('owner_id', session.user.id)
+    .single()
+
+  if (!room) {
     return NextResponse.json({ error: 'Game not found' }, { status: 404 })
   }
 
-  // povol len zo stavu waiting
-  if (game.status !== 'waiting') {
+  const { data: sessionRow } = await supabase
+    .from('game_sessions')
+    .select('id, status')
+    .eq('room_id', room.id)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single()
+
+  if (!sessionRow) {
+    return NextResponse.json({ error: 'Game not found' }, { status: 404 })
+  }
+
+  if (sessionRow.status !== 'waiting') {
     return NextResponse.json({ error: 'Lobby already closed' }, { status: 400 })
   }
 
-  game.status = 'setup'
-  // voliteľne si vynuluj pomocné polia
-  ;(game as any).usedQuestionIds = []
-  game.rounds = game.rounds ?? []
+  const { data: updated, error } = await supabase
+    .from('game_sessions')
+    .update({ status: 'setup' })
+    .eq('id', sessionRow.id)
+    .select('status')
+    .single()
 
-  return NextResponse.json({ success: true, status: game.status })
+  if (error || !updated) {
+    return NextResponse.json({ error: error?.message || 'Unable to lock lobby' }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true, status: updated.status })
 }


### PR DESCRIPTION
## Summary
- Replace in-memory store lookup for lock lobby with Supabase queries and update game session status

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9638ed08c8327afd4fb21a21f46f3