### PR TITLE
Wrap navigation CTA with link to play page

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import Link from "next/link";
 import { Heart, Menu, X } from "lucide-react";
 import { useState } from "react";
 
@@ -39,9 +40,9 @@ const Navigation = () => {
 
           {/* CTA Button */}
           <div className="hidden md:block">
-            <Button variant="hero" size="sm">
-              Začať teraz
-            </Button>
+            <Link href="/sk/apps/spoznajme-sa/play">
+              <Button variant="hero" size="sm">Začať teraz</Button>
+            </Link>
           </div>
 
           {/* Mobile Menu Button */}


### PR DESCRIPTION
## Summary
- wrap desktop navigation CTA button with a link to `/sk/apps/spoznajme-sa/play`

## Testing
- `npm test`
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'next')*
- `npm run dev` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a99a53f483278a7962af5c29a5be