### PR TITLE
Remove legacy Tailwind path

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,7 +7,6 @@ const config: Config = {
     "./pages/**/*.{ts,tsx}",
     "./components/**/*.{ts,tsx}",
     "./src/**/*.{ts,tsx}",
-    "./legacy/**/*.{ts,tsx}",
   ],
   theme: {
     container: {


### PR DESCRIPTION
## Summary
- remove legacy folder from Tailwind content config

## Testing
- `npm test`
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a99c995c8327a352620e7831305e