### PR TITLE
fix: ignore peer deps conflicts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## Summary
- add npmrc to ignore peer dependency conflicts during install

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test`
- `npm run lint` *(fails: next: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a88f7ee88327b70ef2612887b311