### PR TITLE
Add redirects for legacy URLs

### DIFF
--- a/docs/legacy-urls.md
+++ b/docs/legacy-urls.md
@@ -1,0 +1,25 @@
+# Legacy URLs
+
+The following legacy paths redirect to their modern equivalents.
+
+| Old address | New address |
+| --- | --- |
+| `/:lang/pomocky` | `/:lang/kompas` |
+| `/:lang/pomocky/rodic-dieta` | `/:lang/kompas/publikum/rodic-dieta` |
+| `/:lang/pomocky/pary` | `/:lang/kompas/publikum/pary` |
+| `/:lang/pomocky/kamarati-party` | `/:lang/kompas/publikum/kamarati-party` |
+| `/:lang/pomocky/rodina` | `/:lang/kompas/publikum/rodina` |
+| `/:lang/pomocky/audience/:aud` | `/:lang/kompas/publikum/:aud` |
+| `/:lang/pomocky/audience/:aud/tema/:topic` | `/:lang/kompas/tema/:topic` |
+| `/:lang/pomocky/audience/:aud/tema/:topic/:tech` | `/:lang/kompas/tema/:topic` |
+| `/:lang/pomocky/:aud/:topic`<sup>*</sup> | `/:lang/kompas/tema/:topic` |
+| `/:lang/pomocky/:aud/:topic/:tech`<sup>*</sup> | `/:lang/kompas/tema/:topic` |
+| `/:lang/pomocky/tema/:topic` | `/:lang/kompas/tema/:topic` |
+| `/:lang/pomocky/tema/:topic/:tech` | `/:lang/kompas/tema/:topic` |
+| `/:lang/pomocky/rodic-dieta/indexy` | `/:lang/indexy` |
+| `/:lang/pomocky/rodic-dieta/indexy/co-trapi-rodicov` | `/:lang/indexy/co-trapi-rodicov` |
+| `/:lang/pomocky/rodic-dieta/indexy/co-trapi-deti` | `/:lang/indexy/co-trapi-deti` |
+
+<sup>*</sup> `:aud` represents one of `rodic-dieta`, `pary`, `kamarati-party`, or `rodina`.
+
+This list was compiled from historic rewrites, sitemap entries, and menu links.

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,26 @@ const nextConfig: NextConfig = {
     const r: { source: string; destination: string; permanent: boolean }[] = []
     for (const l of SUP) {
       r.push({ source: `/${l}/pomocky`, destination: `/${l}/kompas`, permanent: true })
+
+      const AUD = ["rodic-dieta", "pary", "kamarati-party", "rodina"]
+      for (const a of AUD) {
+        r.push({ source: `/${l}/pomocky/${a}`, destination: `/${l}/kompas/publikum/${a}`, permanent: true })
+        r.push({ source: `/${l}/pomocky/${a}/:topic`, destination: `/${l}/kompas/tema/:topic`, permanent: true })
+        r.push({ source: `/${l}/pomocky/${a}/:topic/:tech`, destination: `/${l}/kompas/tema/:topic`, permanent: true })
+      }
+
+      r.push({ source: `/${l}/pomocky/audience/:aud`, destination: `/${l}/kompas/publikum/:aud`, permanent: true })
+      r.push({ source: `/${l}/pomocky/audience/:aud/tema/:topic`, destination: `/${l}/kompas/tema/:topic`, permanent: true })
+      r.push({ source: `/${l}/pomocky/audience/:aud/tema/:topic/:tech`, destination: `/${l}/kompas/tema/:topic`, permanent: true })
+
+      r.push({ source: `/${l}/pomocky/:topic`, destination: `/${l}/kompas/tema/:topic`, permanent: true })
+      r.push({ source: `/${l}/pomocky/:topic/:tech`, destination: `/${l}/kompas/tema/:topic`, permanent: true })
+      r.push({ source: `/${l}/pomocky/tema/:topic`, destination: `/${l}/kompas/tema/:topic`, permanent: true })
+      r.push({ source: `/${l}/pomocky/tema/:topic/:tech`, destination: `/${l}/kompas/tema/:topic`, permanent: true })
+
+      r.push({ source: `/${l}/pomocky/rodic-dieta/indexy`, destination: `/${l}/indexy`, permanent: true })
+      r.push({ source: `/${l}/pomocky/rodic-dieta/indexy/co-trapi-rodicov`, destination: `/${l}/indexy/co-trapi-rodicov`, permanent: true })
+      r.push({ source: `/${l}/pomocky/rodic-dieta/indexy/co-trapi-deti`, destination: `/${l}/indexy/co-trapi-deti`, permanent: true })
     }
     r.push({ source: `/pomocky`, destination: `/sk/kompas`, permanent: true })
 


### PR DESCRIPTION
## Summary
- list historical pomocky URLs and their replacements
- redirect legacy pomocky and indexy paths to new kompas structure

## Testing
- `npm test`
- `npm run lint` *(fails: next not found, dependencies unavailable)*
- `npm run typecheck` *(fails: missing type definitions for next and node)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ac18ce708327980df77eb7fbc948