### PR TITLE
fix lint plugin error and image types

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,6 @@
 import js from "@eslint/js";
 import globals from "globals";
 import reactHooks from "eslint-plugin-react-hooks";
-import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
@@ -15,14 +14,9 @@ export default tseslint.config(
     },
     plugins: {
       "react-hooks": reactHooks,
-      "react-refresh": reactRefresh,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      "react-refresh/only-export-components": [
-        "warn",
-        { allowConstantExport: true },
-      ],
       "@typescript-eslint/no-unused-vars": "off",
     },
   }

--- a/src/components/FeatureCard.tsx
+++ b/src/components/FeatureCard.tsx
@@ -1,10 +1,11 @@
 import { Button } from "@/components/ui/button";
 import { ArrowRight } from "lucide-react";
+import Image, { StaticImageData } from "next/image";
 
 interface FeatureCardProps {
   title: string;
   description: string;
-  image: string;
+  image: string | StaticImageData;
   imageAlt: string;
   ctaText: string;
   href: string;
@@ -33,9 +34,11 @@ const FeatureCard = ({
       hover:scale-105 hover:-translate-y-2 border border-border/30
     `}>
       <div className="aspect-square w-24 h-24 mx-auto mb-6 rounded-2xl overflow-hidden shadow-soft">
-        <img 
-          src={image} 
+        <Image
+          src={image}
           alt={imageAlt}
+          width={96}
+          height={96}
           className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-300"
         />
       </div>


### PR DESCRIPTION
## Summary
- fix ESLint configuration by removing unused `eslint-plugin-react-refresh`
- use Next.js `Image` component for feature cards and accept `StaticImageData`

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden to registry)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ae4c6b948327a5ad21f6ebbf5835