### PR TITLE
Add herdvote store unit tests with Vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "echo \"(zatím bez testov)\" && exit 0"
+    "test": "vitest run"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.11",
@@ -76,6 +76,7 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
     "tailwindcss-animate": "^1.0.7",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.6.0"
   }
 }

--- a/src/lib/__tests__/herdvote-store.test.ts
+++ b/src/lib/__tests__/herdvote-store.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import store from '../herdvote/store';
+
+const sampleQuestion = {
+  id: 'q1',
+  question_text: 'What is 2+2?',
+  options: ['1','2','3','4'] as [string,string,string,string],
+  correct_answer: 'D',
+  time_limit: 30,
+  points_correct: 1,
+  points_incorrect: 0,
+  theme: null,
+};
+
+const sampleSettings = {
+  timeLimit: 30,
+  scoring: { mode: 'classic', correct: 1, incorrect: 0, none: 0 },
+};
+
+describe('herdvote store', () => {
+  beforeEach(() => {
+    store.games.clear();
+  });
+
+  it('creates a game with default values', () => {
+    const game = store.createGame();
+    expect(game.code).toHaveLength(6);
+    expect(game.status).toBe('waiting');
+    expect(game.players).toHaveLength(0);
+    expect(store.getGame(game.code)).toEqual(game);
+  });
+
+  it('adds a round to a game', () => {
+    const game = store.createGame();
+    const round = store.addRound(game.code, 'math', [sampleQuestion], sampleSettings);
+    expect(round).not.toBeNull();
+    expect(game.rounds).toHaveLength(1);
+    expect(game.rounds[0].category).toBe('math');
+  });
+
+  it('retrieves a player answer', () => {
+    const game = store.createGame();
+    const round = store.addRound(game.code, 'math', [sampleQuestion], sampleSettings);
+    if (!round) throw new Error('round not created');
+    const answer = { playerId: 'p1', roundId: round.id, qIndex: 0, answer: 'A' as const, ts: Date.now() };
+    game.answers.push(answer);
+    expect(store.getPlayerAnswer('p1', round.id, 0)).toEqual(answer);
+    expect(store.getPlayerAnswer('p2', round.id, 0)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest and npm test script
- cover herdvote store's createGame, addRound and getPlayerAnswer

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e9c99c388327babf053c0bf7b67a