### PR TITLE
refactor: strengthen API typings and remove anys

### DIFF
--- a/src/app/api/games/[code]/answers/route.ts
+++ b/src/app/api/games/[code]/answers/route.ts
@@ -1,29 +1,35 @@
 import { NextResponse } from 'next/server'
-import { store } from '@/lib/herdvote/store'
+import { store, type Player, type PlayerAnswer } from '@/lib/herdvote/store'
 import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-export async function POST(req: Request, context: any) {
+interface RouteContext {
+  params: { code: string }
+}
+
+interface AnswerBody {
+  playerId: string
+  roundId: string
+  qIndex: number
+  answer: 'A' | 'B' | 'C' | 'D' | null
+}
+
+export async function POST(req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = (context?.params ?? {}) as { code: string }
+  const { code } = context.params
   const gameCode = String(code || '').toUpperCase()
   const game = store.getGame(gameCode)
   if (!game) return NextResponse.json({ error: 'Game not found' }, { status: 404 })
 
-  const body = await req.json().catch(() => ({} as any))
-  const { playerId, roundId, qIndex, answer } = body as {
-    playerId: string
-    roundId: string
-    qIndex: number
-    answer: 'A'|'B'|'C'|'D'|null
-  }
+  const body = (await req.json().catch(() => ({}))) as Partial<AnswerBody>
+  const { playerId, roundId, qIndex, answer } = body
 
   if (!playerId || !roundId || typeof qIndex !== 'number') {
     return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
   }
-  const player = game.players.find(p => p.id === playerId)
+  const player = game.players.find((p: Player) => p.id === playerId)
   if (!player) return NextResponse.json({ error: 'Player not found' }, { status: 404 })
   const round = game.rounds.find(r => r.id === roundId)
   if (!round) return NextResponse.json({ error: 'Round not found' }, { status: 404 })
@@ -31,14 +37,14 @@ export async function POST(req: Request, context: any) {
     return NextResponse.json({ error: 'Round is not accepting answers' }, { status: 400 })
   }
 
-  // bez typovej kolízie – držíme odpovede na úrovni hry
-  ;(game as any).answers = (game as any).answers ?? []
-  const key = `${playerId}:${roundId}:${qIndex}`
-  const existing = (game as any).answers.findIndex((a: any) => a.key === key)
-  const entry = { key, playerId, roundId, qIndex, answer, ts: Date.now() }
+  const existingIndex = game.answers.findIndex(
+    (a: PlayerAnswer) =>
+      a.playerId === playerId && a.roundId === roundId && a.qIndex === qIndex
+  )
+  const entry: PlayerAnswer = { playerId, roundId, qIndex, answer: answer ?? null, ts: Date.now() }
 
-  if (existing >= 0) (game as any).answers[existing] = entry
-  else (game as any).answers.push(entry)
+  if (existingIndex >= 0) game.answers[existingIndex] = entry
+  else game.answers.push(entry)
 
   return NextResponse.json({ ok: true })
 }

--- a/src/app/api/games/[code]/config/route.ts
+++ b/src/app/api/games/[code]/config/route.ts
@@ -6,14 +6,18 @@ import { getSession } from '@/app/api/games/_session'
 export const dynamic = 'force-dynamic'
 
 // (voliteľné) Načítanie aktuálnej konfigurácie hry
-export async function GET(_req: Request, context: any) {
+interface RouteContext {
+  params: { code: string }
+}
+
+export async function GET(_req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = (context?.params ?? {}) as { code: string }
+  const { code } = context.params
 
   // Ak chceš, môžeš čítať z DB. Tu ponechám stub, aby build vždy prešiel.
   // try {
-  //   const s = supabaseServer() as any
+  //   const s = supabaseServer()
   //   const { data, error } = await s.from('herd_games').select('*').eq('code', code).single()
   //   if (error) return NextResponse.json({ error: error.message }, { status: 404 })
   //   return NextResponse.json({ ok: true, code, config: data })
@@ -27,15 +31,21 @@ export async function GET(_req: Request, context: any) {
 }
 
 // Uloženie / update konfigurácie hry
-export async function POST(req: Request, context: any) {
+interface ConfigBody {
+  rounds?: number
+  prepSeconds?: number
+  scoring?: string
+}
+
+export async function POST(req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = (context?.params ?? {}) as { code: string }
+  const { code } = context.params
 
-  const body = await req.json().catch(() => ({} as any))
+  const body = (await req.json().catch(() => ({}))) as ConfigBody
 
   // Povolené polia (uprav podľa schémy)
-  const updates: Record<string, any> = {}
+  const updates: Partial<{ rounds: number; prep_seconds: number; scoring: string }> = {}
   if (typeof body.rounds === 'number') updates.rounds = body.rounds
   if (typeof body.prepSeconds === 'number') updates.prep_seconds = body.prepSeconds
   if (typeof body.scoring === 'string') updates.scoring = body.scoring
@@ -46,7 +56,7 @@ export async function POST(req: Request, context: any) {
 
   // Zápis do DB s ochranou (aby build nepadal, keď Supabase nie je k dispozícii)
   // try {
-  //   const s = supabaseServer() as any
+  //   const s = supabaseServer()
   //   const { error } = await s.from('herd_games').update(updates).eq('code', code)
   //   if (error) return NextResponse.json({ error: error.message }, { status: 400 })
   //   return NextResponse.json({ ok: true, code, updates })

--- a/src/app/api/games/[code]/leaderboard/route.ts
+++ b/src/app/api/games/[code]/leaderboard/route.ts
@@ -1,14 +1,18 @@
 // PATH: src/app/api/games/[code]/leaderboard/route.ts
 import { NextResponse } from 'next/server'
-import { store } from '@/lib/herdvote/store'
+import { store, type Player } from '@/lib/herdvote/store'
 import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-export async function GET(_req: Request, context: any) {
+interface RouteContext {
+  params: { code: string }
+}
+
+export async function GET(_req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = (context?.params ?? {}) as { code: string }
+  const { code } = context.params
   const gameCode = String(code || '').toUpperCase()
 
   const game = store.getGame(gameCode)
@@ -19,7 +23,7 @@ export async function GET(_req: Request, context: any) {
 
   const leaderboard = [...(game.players ?? [])]
     .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
-    .map(p => ({ name: p.name, score: p.score ?? 0 }))
+    .map((p: Player) => ({ name: p.name, score: p.score ?? 0 }))
 
   return NextResponse.json(leaderboard)
 }

--- a/src/app/api/games/[code]/players/route.ts
+++ b/src/app/api/games/[code]/players/route.ts
@@ -6,8 +6,12 @@ import { randomUUID } from 'crypto'
 export const dynamic = 'force-dynamic'
 
 // GET – vráti lobby (zoznam hráčov)
-export async function GET(_req: Request, context: any) {
-  const { code } = (context?.params ?? {}) as { code: string }
+interface RouteContext {
+  params: { code: string }
+}
+
+export async function GET(_req: Request, context: RouteContext) {
+  const { code } = context.params
   const gameCode = String(code || '').toUpperCase()
 
   const supabase = supabaseServer()
@@ -42,15 +46,17 @@ export async function GET(_req: Request, context: any) {
 }
 
 // POST – pridá hráča (kým je lobby otvorená)
-export async function POST(req: Request, context: any) {
-  const { code } = (context?.params ?? {}) as { code: string }
+interface JoinBody { name?: string; guestId?: string }
+
+export async function POST(req: Request, context: RouteContext) {
+  const { code } = context.params
   const gameCode = String(code || '').toUpperCase()
 
-  const body = await req.json().catch(() => ({} as any))
-  const name = String(body?.name || '').trim()
+  const body = (await req.json().catch(() => ({}))) as JoinBody
+  const name = String(body.name || '').trim()
   if (!name) return NextResponse.json({ error: 'Missing name' }, { status: 400 })
 
-  const guestId = body?.guestId || randomUUID()
+  const guestId = body.guestId || randomUUID()
 
   const supabase = supabaseServer()
   const { data, error } = await supabase.rpc('join_room', {

--- a/src/app/api/games/[code]/rounds/[roundId]/question/route.ts
+++ b/src/app/api/games/[code]/rounds/[roundId]/question/route.ts
@@ -1,16 +1,18 @@
 // PATH: src/app/api/games/[code]/rounds/[roundId]/question/route.ts
 import { NextResponse } from 'next/server'
-import { store } from '@/lib/herdvote/store'
+import { store, type Question } from '@/lib/herdvote/store'
 import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
 type FourAnswers = { answer_a?: string; answer_b?: string; answer_c?: string; answer_d?: string }
 
-export async function GET(_req: Request, context: any) {
+interface RouteContext { params: { code: string; roundId: string } }
+
+export async function GET(_req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code, roundId } = (context?.params ?? {}) as { code: string; roundId: string }
+  const { code, roundId } = context.params
   const gameCode = String(code || '').toUpperCase()
 
   const game = store.getGame(gameCode)
@@ -36,15 +38,19 @@ export async function GET(_req: Request, context: any) {
 
   // Bezpečný fallback pre možnosti:
   let optionsArray: string[]
-  if (Array.isArray((question as any).options) && (question as any).options.length > 0) {
-    optionsArray = (question as any).options as string[]
+  let questionText = ''
+  if ('options' in question && Array.isArray((question as Question).options)) {
+    const q = question as Question
+    optionsArray = q.options
+    questionText = q.question_text
   } else {
-    const q = question as unknown as FourAnswers
-    optionsArray = [q.answer_a, q.answer_b, q.answer_c, q.answer_d].filter(Boolean) as string[]
+    const q = question as FourAnswers & { text?: string; question_text?: string }
+    optionsArray = [q.answer_a, q.answer_b, q.answer_c, q.answer_d].filter((o): o is string => !!o)
+    questionText = q.question_text ?? q.text ?? ''
   }
 
   return NextResponse.json({
-    text: (question as any).question_text ?? (question as any).text ?? '',
+    text: questionText,
     options: optionsArray,
     timeLeft: Math.ceil(timeLeft / 1000),
     qIndex,

--- a/src/app/api/games/[code]/rounds/config/route.ts
+++ b/src/app/api/games/[code]/rounds/config/route.ts
@@ -5,17 +5,22 @@ import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-export async function POST(req: Request, context: any) {
+interface RouteContext { params: { code: string } }
+
+export async function POST(req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  // Next 15 je prísny na typ 2. argumentu – použijeme voľný "context: any"
-  const { code } = (context?.params ?? {}) as { code: string }
+  const { code } = context.params
 
   // bezpečné načítanie body
-  const body = await req.json().catch(() => ({} as any))
+  const body = (await req.json().catch(() => ({}))) as {
+    index?: number
+    topic?: string
+    questions?: unknown
+  }
   const { index, topic, questions } = body
 
-  const s = supabaseServer() as any // "as any" obíde TS typy generované zo Supabase
+  const s = supabaseServer()
 
   // uloženie/aktualizácia kola (idempotentne podľa game_code + index)
   const { error } = await s

--- a/src/app/api/games/[code]/rounds/lock/route.ts
+++ b/src/app/api/games/[code]/rounds/lock/route.ts
@@ -7,11 +7,12 @@ import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-export async function POST(req: Request, context: any) {
+interface RouteContext { params: { code: string } }
+
+export async function POST(req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  // bezpečne vezmeme route parametre
-  const { code } = (context?.params ?? {}) as { code: string }
+  const { code } = context.params
   const gameCode = String(code || '').toUpperCase()
 
   const game = store.getGame(gameCode)
@@ -19,8 +20,8 @@ export async function POST(req: Request, context: any) {
     return NextResponse.json({ error: 'Game not found' }, { status: 404 })
   }
 
-  const body = await req.json().catch(() => ({} as any))
-  const { roundId } = body ?? {}
+  const body = (await req.json().catch(() => ({}))) as { roundId?: string }
+  const { roundId } = body
 
   // nájdi cieľové kolo: podľa roundId alebo práve aktívne
   const targetRound = roundId

--- a/src/app/api/games/[code]/rounds/next/route.ts
+++ b/src/app/api/games/[code]/rounds/next/route.ts
@@ -1,16 +1,19 @@
 // PATH: src/app/api/games/[code]/rounds/next/route.ts
 import { NextResponse } from 'next/server'
-import { store } from '@/lib/herdvote/store'
+import { store, type Player } from '@/lib/herdvote/store'
 import { RealtimeServer } from '@/lib/realtime/server'
 import { channelFor } from '@/lib/realtime/types'
 import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-export async function POST(req: Request, context: any) {
+interface RouteContext { params: { code: string } }
+interface NextBody { roundId?: string }
+
+export async function POST(req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = (context?.params ?? {}) as { code: string }
+  const { code } = context.params
   const gameCode = String(code || '').toUpperCase()
 
   const game = store.getGame(gameCode)
@@ -18,7 +21,7 @@ export async function POST(req: Request, context: any) {
     return NextResponse.json({ error: 'Game not found' }, { status: 404 })
   }
 
-  const body = await req.json().catch(() => ({} as any))
+  const body = (await req.json().catch(() => ({}))) as NextBody
   const { roundId } = body
 
   // nájdi kolo v stave "results"
@@ -37,7 +40,7 @@ export async function POST(req: Request, context: any) {
   if (nextQIndex >= targetRound.questions.length) {
     targetRound.status = 'finished'
 
-    const leaderboard = [...game.players].sort((a, b) => b.score - a.score)
+    const leaderboard: Player[] = [...game.players].sort((a, b) => b.score - a.score)
 
     await RealtimeServer.publish(channelFor(gameCode), {
       type: 'round:finish',

--- a/src/app/api/games/[code]/rounds/results/route.ts
+++ b/src/app/api/games/[code]/rounds/results/route.ts
@@ -1,6 +1,6 @@
 // PATH: src/app/api/games/[code]/rounds/results/route.ts
 import { NextResponse } from 'next/server'
-import { store } from '@/lib/herdvote/store'
+import { store, type Player } from '@/lib/herdvote/store'
 import { RealtimeServer } from '@/lib/realtime/server'
 import { channelFor } from '@/lib/realtime/types'
 import { calculateRoundScores } from '@/lib/herdvote/scoring'
@@ -8,10 +8,13 @@ import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-export async function POST(req: Request, context: any) {
+interface RouteContext { params: { code: string } }
+interface ResultsBody { roundId?: string }
+
+export async function POST(req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = (context?.params ?? {}) as { code: string }
+  const { code } = context.params
   const gameCode = String(code || '').toUpperCase()
 
   const game = store.getGame(gameCode)
@@ -19,7 +22,7 @@ export async function POST(req: Request, context: any) {
     return NextResponse.json({ error: 'Game not found' }, { status: 404 })
   }
 
-  const body = await req.json().catch(() => ({} as any))
+  const body = (await req.json().catch(() => ({}))) as ResultsBody
   const { roundId } = body
 
   // nájdi uzamknuté kolo
@@ -38,11 +41,11 @@ export async function POST(req: Request, context: any) {
   }
 
   // zabezpeč, aby pole answers existovalo (niektoré verzie store ho nemajú)
-  ;(game as any).answers ||= []
+  game.answers ||= []
 
   // výpočet bodov pre aktuálnu otázku
   const questionScores = calculateRoundScores(
-    (game as any).answers,
+    game.answers,
     currentQuestion,
     targetRound.id,
     qIndex,
@@ -59,7 +62,7 @@ export async function POST(req: Request, context: any) {
   targetRound.status = 'results'
 
   // zoradený rebríček
-  const leaderboard = [...game.players].sort((a, b) => b.score - a.score)
+  const leaderboard: Player[] = [...game.players].sort((a, b) => b.score - a.score)
 
   // realtime event
   await RealtimeServer.publish(channelFor(gameCode), {

--- a/src/app/api/games/[code]/rounds/route.ts
+++ b/src/app/api/games/[code]/rounds/route.ts
@@ -1,7 +1,6 @@
 // PATH: src/app/api/games/[code]/rounds/route.ts
 import { NextResponse } from 'next/server'
-import { store } from '@/lib/herdvote/store'
-import type { RoundSettings } from '@/lib/herdvote/store'
+import { store, type RoundSettings } from '@/lib/herdvote/store'
 import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
@@ -15,10 +14,17 @@ export const dynamic = 'force-dynamic'
  *   "settings": { timeLimit: 30, scoring: {...} } as RoundSettings
  * }
  */
-export async function POST(req: Request, context: any) {
+interface RouteContext { params: { code: string } }
+interface RoundBody {
+  category?: string
+  count?: number
+  settings?: RoundSettings
+}
+
+export async function POST(req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = (context?.params ?? {}) as { code: string }
+  const { code } = context.params
   const gameCode = String(code || '').toUpperCase()
 
   const game = store.getGame(gameCode)
@@ -26,10 +32,10 @@ export async function POST(req: Request, context: any) {
     return NextResponse.json({ error: 'Game not found' }, { status: 404 })
   }
 
-  const body = await req.json().catch(() => ({} as any))
-  const rawCategory = String(body?.category || '').trim()
-  const count = Math.max(1, Math.min(100, Number(body?.count || 10)))
-  const settings = body?.settings as RoundSettings | undefined
+  const body = (await req.json().catch(() => ({}))) as RoundBody
+  const rawCategory = String(body.category || '').trim()
+  const count = Math.max(1, Math.min(100, Number(body.count || 10)))
+  const settings = body.settings
 
   if (!rawCategory) {
     return NextResponse.json({ error: 'Missing category' }, { status: 400 })
@@ -50,8 +56,8 @@ export async function POST(req: Request, context: any) {
     return NextResponse.json({ error: 'Category not available' }, { status: 400 })
   }
 
-  const usedIds: string[] = (game as any).usedQuestionIds || []
-  ;(game as any).usedQuestionIds = usedIds
+  const usedIds: string[] = game.usedQuestionIds || []
+  game.usedQuestionIds = usedIds
 
   // Mock otázky (kým nemáš prístup k herd_questions)
   const mockQuestions = Array.from({ length: count }, (_, i) => ({
@@ -100,7 +106,7 @@ export async function POST(req: Request, context: any) {
   }
 
   usedIds.push(...picked.map(p => p.id))
-  ;(game as any).usedQuestionIds = Array.from(new Set(usedIds))
+  game.usedQuestionIds = Array.from(new Set(usedIds))
 
   return NextResponse.json({ roundId: round.id })
 }

--- a/src/app/api/games/[code]/rounds/start/route.ts
+++ b/src/app/api/games/[code]/rounds/start/route.ts
@@ -7,16 +7,19 @@ import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-export async function POST(req: Request, context: any) {
+interface RouteContext { params: { code: string } }
+interface StartBody { roundId?: string }
+
+export async function POST(req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = (context?.params ?? {}) as { code: string }
+  const { code } = context.params
 
   const gameCode = String(code || '').toUpperCase()
   const game = store.getGame(gameCode)
   if (!game) return NextResponse.json({ error: 'Game not found' }, { status: 404 })
 
-  const body = await req.json().catch(() => ({} as any))
+  const body = (await req.json().catch(() => ({}))) as StartBody
   const { roundId } = body
 
   // vyber kolo: buď podľa roundId, alebo prvé pending/ready

--- a/src/app/api/games/[code]/rounds/timer/start/route.ts
+++ b/src/app/api/games/[code]/rounds/timer/start/route.ts
@@ -7,19 +7,22 @@ import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-export async function POST(req: Request, context: any) {
+interface RouteContext { params: { code: string } }
+interface TimerBody { seconds?: number; duration?: number; roundId?: string }
+
+export async function POST(req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = (context?.params ?? {}) as { code: string }
+  const { code } = context.params
   const gameCode = String(code || '').toUpperCase()
 
   const game = store.getGame(gameCode)
   if (!game) return NextResponse.json({ error: 'Game not found' }, { status: 404 })
 
-  const body = await req.json().catch(() => ({} as any))
-  const seconds = Number(body?.seconds ?? body?.duration ?? 45)
-  const round = body?.roundId
-    ? game.rounds.find((r: any) => r.id === body.roundId)
+  const body = (await req.json().catch(() => ({}))) as TimerBody
+  const seconds = Number(body.seconds ?? body.duration ?? 45)
+  const round = body.roundId
+    ? game.rounds.find(r => r.id === body.roundId)
     : store.getActiveRound(gameCode)
 
   if (!round) return NextResponse.json({ error: 'Round not found' }, { status: 404 })
@@ -31,7 +34,7 @@ export async function POST(req: Request, context: any) {
   const deadlineMs = startedAt + seconds * 1000
   round.status = 'running'
   round.startedAt = startedAt
-  ;(round as any).deadline = deadlineMs
+  round.deadline = deadlineMs
 
   // Best-effort persist do DB (pre refreshy klientov) - commented out due to missing table
   // try {

--- a/src/app/api/games/[code]/route.ts
+++ b/src/app/api/games/[code]/route.ts
@@ -4,10 +4,12 @@ import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
-export async function GET(_req: Request, context: any) {
+interface RouteContext { params: { code: string } }
+
+export async function GET(_req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = (context?.params ?? {}) as { code: string }
+  const { code } = context.params
 
   const gameCode = String(code || '').toUpperCase()
   const supabase = supabaseServer()

--- a/src/app/api/games/[code]/start/route.ts
+++ b/src/app/api/games/[code]/start/route.ts
@@ -4,7 +4,7 @@ import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
-export async function POST(_req: Request, _context: any) {
+export async function POST(_req: Request) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 

--- a/src/components/IntlProvider.tsx
+++ b/src/components/IntlProvider.tsx
@@ -2,7 +2,8 @@
 import { createContext, useContext } from 'react'
 import type { Locale } from '@/i18n/config'
 
-type Ctx = { lang: Locale; dict: Record<string, any> }
+type Dict = Record<string, unknown>
+type Ctx = { lang: Locale; dict: Dict }
 const I18nCtx = createContext<Ctx | null>(null)
 
 // minimalistický EN fallback (UI nespadne, kým sa provider nenačíta)
@@ -11,7 +12,7 @@ const FALLBACK_DICT = {
   nav: { home: 'Home', products: 'Products', tools: 'Tools', blog: 'Blog', downloads: 'Downloads' },
 }
 
-export function IntlProvider({ lang, dict, children }: { lang: Locale; dict: any; children: React.ReactNode }) {
+export function IntlProvider({ lang, dict, children }: { lang: Locale; dict: Dict; children: React.ReactNode }) {
   return <I18nCtx.Provider value={{ lang, dict }}>{children}</I18nCtx.Provider>
 }
 
@@ -19,13 +20,21 @@ export function useI18n() {
   const ctx = useContext(I18nCtx)
   if (!ctx) {
     const t = (path: string, fallback?: string) =>
-      path.split('.').reduce((acc: any, k) => (acc && acc[k] !== undefined ? acc[k] : undefined), FALLBACK_DICT) ??
-      (fallback ?? path)
+      path
+        .split('.')
+        .reduce<unknown>((acc, k) =>
+          acc && typeof acc === 'object' ? (acc as Dict)[k] : undefined,
+        FALLBACK_DICT) ?? (fallback ?? path)
     return { lang: 'en' as Locale, dict: FALLBACK_DICT, t }
   }
   function t(path: string, fallback?: string) {
-    return path.split('.').reduce((acc: any, k) => (acc && acc[k] !== undefined ? acc[k] : undefined), ctx?.dict || {}) ??
-      (fallback ?? path)
+    return (
+      path
+        .split('.')
+        .reduce<unknown>((acc, k) =>
+          acc && typeof acc === 'object' ? (acc as Dict)[k] : undefined,
+        ctx.dict) ?? (fallback ?? path)
+    )
   }
   return { ...ctx, t }
 }

--- a/src/components/ui/slot.tsx
+++ b/src/components/ui/slot.tsx
@@ -8,7 +8,7 @@ export interface SlotProps extends React.HTMLAttributes<HTMLElement> {
 
 export const Slot = React.forwardRef<HTMLElement, SlotProps>(
   ({ children, className, ...props }, ref) => {
-    const child = React.Children.only(children) as React.ReactElement<any>
+    const child = React.Children.only(children) as React.ReactElement<unknown>
     return React.cloneElement(child, {
       ...props,
       ref,

--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -19,10 +19,15 @@ export const SUPPORTED_LOCALES = [
 export type Locale = typeof SUPPORTED_LOCALES[number]
 export const DEFAULT_LOCALE: Locale = 'en'
 
-const dictionaries: Record<string, Record<string, any>> = { en, sk, cz, de, pl, fr, hu, es, ua, ru }
+const dictionaries: Record<string, Record<string, unknown>> = { en, sk, cz, de, pl, fr, hu, es, ua, ru }
 
-function get(obj: any, path: string) {
-  return path.split('.').reduce((acc, key) => (acc && acc[key] !== undefined ? acc[key] : undefined), obj)
+function get(obj: unknown, path: string): unknown {
+  return path.split('.').reduce<unknown>((acc, key) => {
+    if (acc && typeof acc === 'object' && key in (acc as Record<string, unknown>)) {
+      return (acc as Record<string, unknown>)[key]
+    }
+    return undefined
+  }, obj)
 }
 
 // normalizácia jazykových kódov (cs->cz, uk->ua; zhodenie -SK/-CZ atď.)

--- a/src/i18n/server.ts
+++ b/src/i18n/server.ts
@@ -1,7 +1,7 @@
 // src/i18n/server.ts
 import { FALLBACK_LOCALE, type Locale } from "./config";
 
-type Dict = Record<string, any>;
+type Dict = Record<string, unknown>;
 
 function merge(base: Dict, override: Dict): Dict {
   const out: Dict = { ...base };

--- a/src/integrations/supabase/server.ts
+++ b/src/integrations/supabase/server.ts
@@ -1,6 +1,8 @@
 // PATH: src/integrations/supabase/server.ts
 import 'server-only'
 import { createClient } from '@supabase/supabase-js'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from './types'
 
 /**
  * Server‑only Supabase klient s SERVICE ROLE kľúčom.
@@ -22,9 +24,9 @@ if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
  * Ak je poskytnutý `accessToken`, bude pripojený v `Authorization` hlavičke,
  * aby funkcie používajúce `auth.uid()` vedeli identifikovať moderátora.
  */
-export function supabaseServer(accessToken?: string) {
+export function supabaseServer(accessToken?: string): SupabaseClient<Database> {
   // Pozn.: NEpoužívame persistSession v server prostredí
-  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+  return createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
     auth: { persistSession: false, autoRefreshToken: false },
     global: accessToken
       ? { headers: { Authorization: `Bearer ${accessToken}` } }

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -7,7 +7,7 @@ function readMDXFrontmatter(filePath: string) {
     if (fs.existsSync(filePath)) {
       const raw = fs.readFileSync(filePath, 'utf8')
       const { data } = matter(raw)
-      return data as Record<string, any>
+      return data as Record<string, unknown>
     }
   } catch (e) {
     console.error('MDX read error:', e)

--- a/src/lib/herdvote/store.ts
+++ b/src/lib/herdvote/store.ts
@@ -41,6 +41,7 @@ export type Round = {
   status: 'pending'|'running'|'locked'|'results'|'finished'|'ready'|'shown';
   qIndex: number;     // index aktuálnej otázky
   startedAt?: number; // ms – štart aktuálnej otázky
+  deadline?: number;  // ms – koniec časovača
 };
 
 export type PlayerAnswer = {
@@ -51,17 +52,20 @@ export type PlayerAnswer = {
   ts: number; // ms – čas odoslania
 };
 
+export type GameSettings = Record<string, unknown>;
+
 export type Game = {
   id: string;
   code: string;
   status: 'waiting'|'active'|'finished'|'setup';
-  settings: Record<string, any>;
+  settings: GameSettings;
   players: Player[];
   rounds: Round[];
   answers: PlayerAnswer[]; // všetky odpovede
   createdAt: number;
 
   activeRoundId?: string;
+  usedQuestionIds?: string[];
 };
 
 // ---- helpers ----
@@ -82,7 +86,7 @@ function uuid() {
 export const store = {
   games: new Map<string, Game>(),
 
-  createGame(settings: Record<string, any> = {}) {
+  createGame(settings: GameSettings = {}) {
     const code = pickCode(6);
     const game: Game = {
       id: uuid(),
@@ -136,3 +140,15 @@ export const store = {
 };
 
 export default store;
+
+export type {
+  Player,
+  Question,
+  ScoringClassic,
+  ScoringPodium,
+  RoundSettings,
+  Round,
+  PlayerAnswer,
+  Game,
+  GameSettings,
+};

--- a/src/lib/realtime/client.ts
+++ b/src/lib/realtime/client.ts
@@ -2,6 +2,12 @@
 
 import type { HerdEvent, RealtimeCallback } from './types'
 
+declare global {
+  interface Window {
+    RealtimeClient?: RealtimeClientImpl
+  }
+}
+
 class RealtimeClientImpl {
   private subscribers = new Map<string, Set<RealtimeCallback>>()
   private isConnected = false
@@ -69,5 +75,5 @@ export const RealtimeClient = new RealtimeClientImpl()
 
 // Expose for server simulation in dev
 if (typeof window !== 'undefined') {
-  (window as any).RealtimeClient = RealtimeClient
+  window.RealtimeClient = RealtimeClient
 }

--- a/src/lib/realtime/server.ts
+++ b/src/lib/realtime/server.ts
@@ -2,6 +2,12 @@
 
 import type { HerdEvent } from './types'
 
+declare global {
+  interface Window {
+    RealtimeClient?: { simulateEvent?: (channel: string, event: HerdEvent) => void }
+  }
+}
+
 class RealtimeServerImpl {
   async publish(channel: string, event: HerdEvent): Promise<void> {
     console.log(`[REALTIME] Publishing to ${channel}:`, event)
@@ -21,7 +27,7 @@ class RealtimeServerImpl {
     // Fallback for development: simulate client event reception
     if (typeof window !== 'undefined') {
       // Browser context - send to client directly
-      const client = (window as any).RealtimeClient
+      const client = window.RealtimeClient
       if (client?.simulateEvent) {
         setTimeout(() => client.simulateEvent(channel, event), 50)
       }

--- a/src/lib/realtime/types.ts
+++ b/src/lib/realtime/types.ts
@@ -2,13 +2,15 @@
 
 import type { Player } from '../herdvote/store'
 
+export type LeaderboardEntry = Pick<Player, 'id' | 'name' | 'score'>
+
 export type HerdEvent =
   | { type: 'game:start'; code: string; roundId: string; qIndex: number; at: number }
   | { type: 'question:show'; code: string; roundId: string; qIndex: number; at: number }
   | { type: 'timer:start';   code: string; roundId: string; qIndex: number; startedAt: number; durationSec: number }
   | { type: 'round:lock';    code: string; roundId: string; qIndex: number; at: number }
-  | { type: 'round:results'; code: string; roundId: string; qIndex: number; correct: 'A'|'B'|'C'|'D'; leaderboard: any; at: number }
-  | { type: 'round:finish';  code: string; roundId: string; leaderboard: any; at: number }
+  | { type: 'round:results'; code: string; roundId: string; qIndex: number; correct: 'A'|'B'|'C'|'D'; leaderboard: LeaderboardEntry[]; at: number }
+  | { type: 'round:finish';  code: string; roundId: string; leaderboard: LeaderboardEntry[]; at: number }
 
 export type RealtimeCallback = (event: HerdEvent) => void
 

--- a/src/lib/services/soundService.ts
+++ b/src/lib/services/soundService.ts
@@ -7,7 +7,10 @@ export class SoundService {
     if (typeof window === 'undefined') return
     
     try {
-      this.audioContext = new (window.AudioContext || (window as any).webkitAudioContext)()
+      const AudioCtx =
+        window.AudioContext ||
+        (window as Window & { webkitAudioContext: typeof AudioContext }).webkitAudioContext
+      this.audioContext = new AudioCtx()
     } catch (error) {
       console.warn('AudioContext not supported:', error)
     }


### PR DESCRIPTION
## Summary
- add explicit interfaces for game API routes and remove `any`
- centralize and re-export HerdVote store types
- tighten realtime and utility typings across the project

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'next' and 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68a9e9ccf9988327894d8853110b03f2