### PR TITLE
Fix ESLint config and hero image

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,23 +1,28 @@
 import js from "@eslint/js";
 import globals from "globals";
 import reactHooks from "eslint-plugin-react-hooks";
-import tseslint from "typescript-eslint";
+import tsPlugin from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
 
-export default tseslint.config(
+export default [
   { ignores: ["dist"] },
   {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/*.{ts,tsx}"],
     languageOptions: {
+      parser: tsParser,
       ecmaVersion: 2020,
+      sourceType: "module",
       globals: globals.browser,
     },
     plugins: {
+      "@typescript-eslint": tsPlugin,
       "react-hooks": reactHooks,
     },
     rules: {
+      ...js.configs.recommended.rules,
+      ...tsPlugin.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,
       "@typescript-eslint/no-unused-vars": "off",
     },
-  }
-);
+  },
+];

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { ArrowRight, Heart } from "lucide-react";
+import Image from "next/image";
 import heroImage from "@/assets/hero-connection.jpg";
 
 const Hero = () => {
@@ -7,10 +8,12 @@ const Hero = () => {
     <section className="relative min-h-screen flex items-center justify-center overflow-hidden bg-gradient-warm">
       {/* Background Image with Overlay */}
       <div className="absolute inset-0 z-0">
-        <img 
-          src={heroImage} 
-          alt="People connecting through meaningful conversations" 
-          className="w-full h-full object-cover opacity-20"
+        <Image
+          src={heroImage}
+          alt="People connecting through meaningful conversations"
+          fill
+          className="object-cover opacity-20"
+          priority
         />
         <div className="absolute inset-0 bg-gradient-sunset opacity-10"></div>
       </div>


### PR DESCRIPTION
## Summary
- replace missing `typescript-eslint` package with standard `@typescript-eslint` parser and plugin in ESLint configuration
- update Hero component to use Next.js `Image` component for static hero background image

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f2e5237883278c1ffd515b7f1aa1