### PR TITLE
fix: align answers route handler with Next.js 15

### DIFF
--- a/src/app/api/games/[code]/answers/route.ts
+++ b/src/app/api/games/[code]/answers/route.ts
@@ -4,10 +4,6 @@ import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-interface RouteContext {
-  params: { code: string }
-}
-
 interface AnswerBody {
   playerId: string
   roundId: string
@@ -15,10 +11,13 @@ interface AnswerBody {
   answer: 'A' | 'B' | 'C' | 'D' | null
 }
 
-export async function POST(req: Request, context: RouteContext) {
+export async function POST(
+  req: Request,
+  { params }: { params: { code: string } }
+) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = context.params
+  const { code } = params
   const gameCode = String(code || '').toUpperCase()
   const game = store.getGame(gameCode)
   if (!game) return NextResponse.json({ error: 'Game not found' }, { status: 404 })


### PR DESCRIPTION
## Summary
- fix POST handler to destructure params instead of using deprecated RouteContext

## Testing
- `npm test`
- `npm run build` *(fails: `next` not found; `npm install` returned 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68aa07e12ed883278f92c26369f9f73a