### PR TITLE
fix: inline POST route context type for Next.js 15

### DIFF
--- a/src/app/api/games/[code]/answers/route.ts
+++ b/src/app/api/games/[code]/answers/route.ts
@@ -11,14 +11,13 @@ interface AnswerBody {
   answer: 'A' | 'B' | 'C' | 'D' | null
 }
 
-interface Context {
-  params: { code: string }
-}
-
-export async function POST(req: NextRequest, context: Context) {
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { code: string } }
+) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = context.params
+  const { code } = params
   const gameCode = String(code || '').toUpperCase()
   const game = store.getGame(gameCode)
   if (!game) return NextResponse.json({ error: 'Game not found' }, { status: 404 })


### PR DESCRIPTION
## Summary
- fix POST route handler to use inline params object instead of Context interface

## Testing
- `npm test`
- Attempted `npm run build` *(failed: next: not found after install failure)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0b4930f8832797a4de3ca5cb4b7d