### PR TITLE
fix: await route params

### DIFF
--- a/src/app/api/games/[code]/answers/route.ts
+++ b/src/app/api/games/[code]/answers/route.ts
@@ -13,11 +13,11 @@ interface AnswerBody {
 
 export async function POST(
   req: NextRequest,
-  context: { params: { code: string } }
+  { params }: { params: Promise<{ code: string }> }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = context.params
+  const { code } = await params
   const gameCode = String(code || '').toUpperCase()
   const game = store.getGame(gameCode)
   if (!game) return NextResponse.json({ error: 'Game not found' }, { status: 404 })

--- a/src/app/api/games/[code]/config/route.ts
+++ b/src/app/api/games/[code]/config/route.ts
@@ -7,13 +7,13 @@ export const dynamic = 'force-dynamic'
 
 // (voliteľné) Načítanie aktuálnej konfigurácie hry
 interface RouteContext {
-  params: { code: string }
+  params: Promise<{ code: string }>
 }
 
 export async function GET(_req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = context.params
+  const { code } = await context.params
 
   // Ak chceš, môžeš čítať z DB. Tu ponechám stub, aby build vždy prešiel.
   // try {
@@ -40,7 +40,7 @@ interface ConfigBody {
 export async function POST(req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = context.params
+  const { code } = await context.params
 
   const body = (await req.json().catch(() => ({}))) as ConfigBody
 

--- a/src/app/api/games/[code]/leaderboard/route.ts
+++ b/src/app/api/games/[code]/leaderboard/route.ts
@@ -6,13 +6,13 @@ import { getSession } from '@/app/api/games/_session'
 export const dynamic = 'force-dynamic'
 
 interface RouteContext {
-  params: { code: string }
+  params: Promise<{ code: string }>
 }
 
 export async function GET(_req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = context.params
+  const { code } = await context.params
   const gameCode = String(code || '').toUpperCase()
 
   const game = store.getGame(gameCode)

--- a/src/app/api/games/[code]/players/route.ts
+++ b/src/app/api/games/[code]/players/route.ts
@@ -7,11 +7,11 @@ export const dynamic = 'force-dynamic'
 
 // GET – vráti lobby (zoznam hráčov)
 interface RouteContext {
-  params: { code: string }
+  params: Promise<{ code: string }>
 }
 
 export async function GET(_req: Request, context: RouteContext) {
-  const { code } = context.params
+  const { code } = await context.params
   const gameCode = String(code || '').toUpperCase()
 
   const supabase = supabaseServer()
@@ -49,7 +49,7 @@ export async function GET(_req: Request, context: RouteContext) {
 interface JoinBody { name?: string; guestId?: string }
 
 export async function POST(req: Request, context: RouteContext) {
-  const { code } = context.params
+  const { code } = await context.params
   const gameCode = String(code || '').toUpperCase()
 
   const body = (await req.json().catch(() => ({}))) as JoinBody

--- a/src/app/api/games/[code]/rounds/[roundId]/question/route.ts
+++ b/src/app/api/games/[code]/rounds/[roundId]/question/route.ts
@@ -7,12 +7,12 @@ export const dynamic = 'force-dynamic'
 
 type FourAnswers = { answer_a?: string; answer_b?: string; answer_c?: string; answer_d?: string }
 
-interface RouteContext { params: { code: string; roundId: string } }
+interface RouteContext { params: Promise<{ code: string; roundId: string }> }
 
 export async function GET(_req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code, roundId } = context.params
+  const { code, roundId } = await context.params
   const gameCode = String(code || '').toUpperCase()
 
   const game = store.getGame(gameCode)

--- a/src/app/api/games/[code]/rounds/config/route.ts
+++ b/src/app/api/games/[code]/rounds/config/route.ts
@@ -5,12 +5,12 @@ import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-interface RouteContext { params: { code: string } }
+interface RouteContext { params: Promise<{ code: string }> }
 
 export async function POST(req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = context.params
+  const { code } = await context.params
 
   // bezpečné načítanie body
   const body = (await req.json().catch(() => ({}))) as {

--- a/src/app/api/games/[code]/rounds/lock/route.ts
+++ b/src/app/api/games/[code]/rounds/lock/route.ts
@@ -7,12 +7,12 @@ import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-interface RouteContext { params: { code: string } }
+interface RouteContext { params: Promise<{ code: string }> }
 
 export async function POST(req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = context.params
+  const { code } = await context.params
   const gameCode = String(code || '').toUpperCase()
 
   const game = store.getGame(gameCode)

--- a/src/app/api/games/[code]/rounds/next/route.ts
+++ b/src/app/api/games/[code]/rounds/next/route.ts
@@ -7,13 +7,13 @@ import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-interface RouteContext { params: { code: string } }
+interface RouteContext { params: Promise<{ code: string }> }
 interface NextBody { roundId?: string }
 
 export async function POST(req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = context.params
+  const { code } = await context.params
   const gameCode = String(code || '').toUpperCase()
 
   const game = store.getGame(gameCode)

--- a/src/app/api/games/[code]/rounds/results/route.ts
+++ b/src/app/api/games/[code]/rounds/results/route.ts
@@ -8,13 +8,13 @@ import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-interface RouteContext { params: { code: string } }
+interface RouteContext { params: Promise<{ code: string }> }
 interface ResultsBody { roundId?: string }
 
 export async function POST(req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = context.params
+  const { code } = await context.params
   const gameCode = String(code || '').toUpperCase()
 
   const game = store.getGame(gameCode)

--- a/src/app/api/games/[code]/rounds/route.ts
+++ b/src/app/api/games/[code]/rounds/route.ts
@@ -14,7 +14,7 @@ export const dynamic = 'force-dynamic'
  *   "settings": { timeLimit: 30, scoring: {...} } as RoundSettings
  * }
  */
-interface RouteContext { params: { code: string } }
+interface RouteContext { params: Promise<{ code: string }> }
 interface RoundBody {
   category?: string
   count?: number
@@ -24,7 +24,7 @@ interface RoundBody {
 export async function POST(req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = context.params
+  const { code } = await context.params
   const gameCode = String(code || '').toUpperCase()
 
   const game = store.getGame(gameCode)

--- a/src/app/api/games/[code]/rounds/start/route.ts
+++ b/src/app/api/games/[code]/rounds/start/route.ts
@@ -7,13 +7,13 @@ import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-interface RouteContext { params: { code: string } }
+interface RouteContext { params: Promise<{ code: string }> }
 interface StartBody { roundId?: string }
 
 export async function POST(req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = context.params
+  const { code } = await context.params
 
   const gameCode = String(code || '').toUpperCase()
   const game = store.getGame(gameCode)

--- a/src/app/api/games/[code]/rounds/timer/start/route.ts
+++ b/src/app/api/games/[code]/rounds/timer/start/route.ts
@@ -7,13 +7,13 @@ import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-interface RouteContext { params: { code: string } }
+interface RouteContext { params: Promise<{ code: string }> }
 interface TimerBody { seconds?: number; duration?: number; roundId?: string }
 
 export async function POST(req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = context.params
+  const { code } = await context.params
   const gameCode = String(code || '').toUpperCase()
 
   const game = store.getGame(gameCode)

--- a/src/app/api/games/[code]/route.ts
+++ b/src/app/api/games/[code]/route.ts
@@ -4,12 +4,12 @@ import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
-interface RouteContext { params: { code: string } }
+interface RouteContext { params: Promise<{ code: string }> }
 
 export async function GET(_req: Request, context: RouteContext) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = context.params
+  const { code } = await context.params
 
   const gameCode = String(code || '').toUpperCase()
   const supabase = supabaseServer()


### PR DESCRIPTION
## Summary
- fix Next.js API routes to await async params

## Testing
- `npm test`
- `npm run lint` *(fails: next: not found)*
- `npm run typecheck` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1067fef483279632f0fb34dfcd0b