### PR TITLE
feat(i18n): type dictionary for apps

### DIFF
--- a/src/i18n/server.ts
+++ b/src/i18n/server.ts
@@ -1,5 +1,6 @@
 // src/i18n/server.ts
 import { FALLBACK_LOCALE, type Locale } from "./config";
+import type { Dictionary } from "./types";
 
 type Dict = Record<string, unknown>;
 
@@ -15,12 +16,12 @@ function merge(base: Dict, override: Dict): Dict {
   return out;
 }
 
-export async function getDictionary(locale: Locale): Promise<Dict> {
-  const en = (await import(`./dictionaries/en.json`)).default;
+export async function getDictionary(locale: Locale): Promise<Dictionary> {
+  const en = (await import(`./dictionaries/en.json`)).default as Dictionary;
   if (locale === "en") return en;
   try {
-    const loc = (await import(`./dictionaries/${locale}.json`)).default;
-    return merge(en, loc);
+    const loc = (await import(`./dictionaries/${locale}.json`)).default as Dictionary;
+    return merge(en, loc) as Dictionary;
   } catch {
     return en;
   }

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -1,0 +1,24 @@
+export interface GameEntry {
+  name: string
+  description: string
+  cta: string
+  link: string
+  manual: string[]
+  [key: string]: unknown
+}
+
+export interface GamesDictionary {
+  hadacka: GameEntry
+  ctaBack: string
+  [key: string]: unknown
+}
+
+export interface AppsDictionary {
+  games: GamesDictionary
+  [key: string]: unknown
+}
+
+export interface Dictionary {
+  apps: AppsDictionary
+  [key: string]: unknown
+}


### PR DESCRIPTION
## Summary
- add explicit dictionary interfaces for apps and games
- return typed dictionaries from server helper

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find type definition file for 'next')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa159b30a083278d5393e89c6c5960