### PR TITLE
Define apps dictionary types

### DIFF
--- a/src/app/[lang]/apps/page.tsx
+++ b/src/app/[lang]/apps/page.tsx
@@ -6,6 +6,7 @@ import { type Locale, SUPPORTED_LOCALES } from '@/i18n/config'
 import { normalizeUrlLocale } from '@/lib/i18n-routing'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import type { GameEntry } from '@/i18n/types'
 
 type P = { params: Promise<{ lang: string }> }
 
@@ -50,7 +51,7 @@ export default async function AppsPage({ params }: P) {
             </h2>
             <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
               {cat.slugs.map((slug) => {
-                const g = games[slug]
+                const g = games[slug] as GameEntry
                 return (
                   <Card key={slug}>
                     <Image

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -8,12 +8,20 @@ export interface GameEntry {
 }
 
 export interface GamesDictionary {
+  quiz: GameEntry
+  'spoznajme-sa': GameEntry
   hadacka: GameEntry
+  couplesync: GameEntry
   ctaBack: string
+  how: string
   [key: string]: unknown
 }
 
 export interface AppsDictionary {
+  bannerTitle: string
+  bannerSubtitle: string
+  bannerCTA: string
+  categories: Record<string, string>
   games: GamesDictionary
   [key: string]: unknown
 }


### PR DESCRIPTION
## Summary
- add explicit fields for app and game translations
- treat dynamic game lookups as typed entries

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find type definition file for 'next', attempted `npm install` but received 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1a9158748327ae0d1b9bc866f1d6