### PR TITLE
Fix metadata type handling for index page

### DIFF
--- a/src/app/[lang]/indexy/co-trapi-rodicov/page.tsx
+++ b/src/app/[lang]/indexy/co-trapi-rodicov/page.tsx
@@ -7,14 +7,24 @@ import { buildHreflangAlternates, normalizeUrlLocale } from '@/lib/i18n-routing'
 
 type P = { params: Promise<{ lang: string }> }
 
+interface IndexFrontmatter {
+  title?: string
+  seoDescription?: string
+  description?: string
+}
+
 export async function generateMetadata({ params }: P): Promise<Metadata> {
   const { lang: raw } = await params
   const lang = normalizeUrlLocale(raw)
-  const fm = getIndexFrontmatter(lang, 'co-trapi-rodicov')
+  const fm = getIndexFrontmatter(lang, 'co-trapi-rodicov') as IndexFrontmatter | null
+
+  const title = typeof fm?.title === 'string' ? fm.title : undefined
+  const description =
+    typeof fm?.seoDescription === 'string' ? fm.seoDescription : undefined
 
   return {
-    title: fm?.title || 'Čo trápi rodičov',
-    description: fm?.seoDescription || 'Čoskoro.',
+    title: title ?? 'Čo trápi rodičov',
+    description: description ?? 'Čoskoro.',
     alternates: {
       canonical: `https://deeptalks.eu/${lang}/indexy/co-trapi-rodicov`,
       languages: buildHreflangAlternates('/indexy/co-trapi-rodicov'),
@@ -25,7 +35,7 @@ export async function generateMetadata({ params }: P): Promise<Metadata> {
 export default async function Page({ params }: P) {
   const { lang: raw } = await params
   const lang = normalizeUrlLocale(raw)
-  const fm = getIndexFrontmatter(lang, 'co-trapi-rodicov')
+  const fm = getIndexFrontmatter(lang, 'co-trapi-rodicov') as IndexFrontmatter | null
 
   return (
     <Container>
@@ -37,10 +47,10 @@ export default async function Page({ params }: P) {
         ]}
       />
       <h1 className="text-3xl font-semibold mt-4">
-        {fm?.title || 'Čo trápi rodičov'}
+        {fm?.title ?? 'Čo trápi rodičov'}
       </h1>
       <p className="text-muted-foreground mt-2">
-        {fm?.description || 'Čoskoro.'}
+        {fm?.description ?? 'Čoskoro.'}
       </p>
     </Container>
   )


### PR DESCRIPTION
## Summary
- properly type index frontmatter and guard against non-string values when generating page metadata

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@radix-ui%2freact-accordion)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1d846e908327b1fc119686f35665