### PR TITLE
Fix metadata typing for tool metadata

### DIFF
--- a/src/app/[lang]/pomocky/tema/[tema]/[technika]/page.tsx
+++ b/src/app/[lang]/pomocky/tema/[tema]/[technika]/page.tsx
@@ -11,8 +11,18 @@ export async function generateMetadata({ params }: P): Promise<Metadata> {
   const { lang: raw, tema, technika } = await params
   const lang = normalizeUrlLocale(raw)
   const fm = getToolFrontmatter(lang, tema, technika)
-  const title = fm?.seoTitle || fm?.title || technika
-  const description = fm?.seoDescription || fm?.summary || 'Čoskoro.'
+  const title =
+    typeof fm?.seoTitle === 'string'
+      ? fm.seoTitle
+      : typeof fm?.title === 'string'
+        ? fm.title
+        : technika
+  const description =
+    typeof fm?.seoDescription === 'string'
+      ? fm.seoDescription
+      : typeof fm?.summary === 'string'
+        ? fm.summary
+        : 'Čoskoro.'
   return {
     title,
     description,


### PR DESCRIPTION
## Summary
- ensure `generateMetadata` in tool page returns string title/description

## Testing
- `npm run build` *(fails: next: not found)*
- `npm install` *(fails: 403 Forbidden - @radix-ui/react-accordion)*

------
https://chatgpt.com/codex/tasks/task_e_68aa20ba4f1083279cdfc9206025876c