### PR TITLE
fix: ensure topic metadata uses strings

### DIFF
--- a/src/app/[lang]/pomocky/tema/[tema]/page.tsx
+++ b/src/app/[lang]/pomocky/tema/[tema]/page.tsx
@@ -11,8 +11,10 @@ export async function generateMetadata({ params }: P): Promise<Metadata> {
   const { lang: raw, tema } = await params
   const lang = normalizeUrlLocale(raw)
   const fm = getTopicFrontmatter(lang, tema)
-  const title = fm?.seoTitle || fm?.title || `Téma – ${tema}`
-  const description = fm?.seoDescription || 'Čoskoro.'
+  const rawTitle = fm?.seoTitle ?? fm?.title
+  const title = typeof rawTitle === 'string' ? rawTitle : `Pomôcky – ${tema}`
+  const description =
+    typeof fm?.seoDescription === 'string' ? fm.seoDescription : 'Čoskoro.'
   return {
     title,
     description,


### PR DESCRIPTION
## Summary
- avoid sending objects to Next.js metadata by validating topic frontmatter

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find type definition file for 'next')*
- `npm run lint` *(fails: next: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa248e66488327b3d50cca52843a08