### PR TITLE
Guard topic page frontmatter fields

### DIFF
--- a/src/app/[lang]/pomocky/tema/[tema]/page.tsx
+++ b/src/app/[lang]/pomocky/tema/[tema]/page.tsx
@@ -11,8 +11,10 @@ export async function generateMetadata({ params }: P): Promise<Metadata> {
   const { lang: raw, tema } = await params
   const lang = normalizeUrlLocale(raw)
   const fm = getTopicFrontmatter(lang, tema)
-  const title = fm?.seoTitle || fm?.title || `Téma – ${tema}`
-  const description = fm?.seoDescription || 'Čoskoro.'
+  const rawTitle = fm?.seoTitle ?? fm?.title
+  const title = typeof rawTitle === 'string' ? rawTitle : `Pomôcky – ${tema}`
+  const description =
+    typeof fm?.seoDescription === 'string' ? fm.seoDescription : 'Čoskoro.'
   return {
     title,
     description,
@@ -27,17 +29,20 @@ export default async function Page({ params }: P) {
   const { lang: raw, tema } = await params
   const lang = normalizeUrlLocale(raw)
   const fm = getTopicFrontmatter(lang, tema)
+  const title = typeof fm?.title === 'string' ? fm.title : tema
+  const description =
+    typeof fm?.description === 'string' ? fm.description : 'Čoskoro.'
   return (
     <Container>
       <Breadcrumbs
         items={[
           { href: `/${lang}`, label: 'Domov' },
           { href: `/${lang}/pomocky`, label: 'Pomôcky' },
-          { label: fm?.title || tema },
+          { label: title },
         ]}
       />
-      <h1 className="text-3xl font-semibold mt-4">{fm?.title || tema}</h1>
-      <p className="text-muted-foreground mt-2">{fm?.description || 'Čoskoro.'}</p>
+      <h1 className="text-3xl font-semibold mt-4">{title}</h1>
+      <p className="text-muted-foreground mt-2">{description}</p>
     </Container>
   )
 }


### PR DESCRIPTION
## Summary
- validate topic frontmatter strings before use

## Testing
- `npm test`
- `npm run typecheck` (fails: Cannot find type definition file for 'next' and 'node')
- `npm run lint` (fails: next: not found)
- `npm run build` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68aa248e66488327b3d50cca52843a08