### PR TITLE
fix: add type definition for age map metadata

### DIFF
--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -15,6 +15,12 @@ function readMDXFrontmatter(filePath: string) {
   return null
 }
 
+export interface AgeMapFrontmatter {
+  title?: string
+  description?: string
+  seoDescription?: string
+}
+
 export function getTopicFrontmatter(lang: string, tema: string) {
   const p = path.join(process.cwd(), 'content', lang, 'topics', tema, 'index.mdx')
   return readMDXFrontmatter(p)
@@ -25,9 +31,9 @@ export function getToolFrontmatter(lang: string, tema: string, technika: string)
   return readMDXFrontmatter(p)
 }
 
-export function getAgeMapFrontmatter(lang: string, range: string) {
+export function getAgeMapFrontmatter(lang: string, range: string): AgeMapFrontmatter | null {
   const p = path.join(process.cwd(), 'content', lang, 'age-maps', `${range}.mdx`)
-  return readMDXFrontmatter(p)
+  return readMDXFrontmatter(p) as AgeMapFrontmatter | null
 }
 
 export function getIndexFrontmatter(lang: string, indexKey: string) {


### PR DESCRIPTION
## Summary
- define AgeMapFrontmatter interface
- type getAgeMapFrontmatter to return AgeMapFrontmatter

## Testing
- `npm test`
- `npm run build` *(fails: next not found; npm install 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aa290f42a8832790a8e4f1e44dbd5d