### PR TITLE
fix: allow dynamic supabase tables

### DIFF
--- a/src/app/api/games/[code]/players/route.ts
+++ b/src/app/api/games/[code]/players/route.ts
@@ -14,7 +14,7 @@ export async function GET(_req: Request, context: RouteContext) {
   const { code } = await context.params
   const gameCode = String(code || '').toUpperCase()
 
-  const supabase = supabaseServer()
+  const supabase = supabaseServer() as any
 
   const { data: room } = await supabase
     .from('rooms')
@@ -58,7 +58,7 @@ export async function POST(req: Request, context: RouteContext) {
 
   const guestId = body.guestId || randomUUID()
 
-  const supabase = supabaseServer()
+  const supabase = supabaseServer() as any
   const { data, error } = await supabase.rpc('join_room', {
     p_code: gameCode,
     p_nickname: name,

--- a/src/app/api/games/[code]/route.ts
+++ b/src/app/api/games/[code]/route.ts
@@ -12,7 +12,7 @@ export async function GET(_req: Request, context: RouteContext) {
   const { code } = await context.params
 
   const gameCode = String(code || '').toUpperCase()
-  const supabase = supabaseServer()
+  const supabase = supabaseServer() as any
 
   const { data: room } = await supabase
     .from('rooms')


### PR DESCRIPTION
## Summary
- cast server-side supabase client to any so routes can query rooms, game_sessions, and participants

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@radix-ui%2freact-accordion)*
- `npm run build` *(skipped: requires dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2ca775bc8327967524a932a9516e