### PR TITLE
fix: type participants in players route

### DIFF
--- a/src/app/api/games/[code]/players/route.ts
+++ b/src/app/api/games/[code]/players/route.ts
@@ -40,7 +40,17 @@ export async function GET(_req: Request, context: RouteContext) {
     .select('id, nickname, guest_id')
     .eq('session_id', session.id)
 
-  const players = (participants || []).map(p => ({ id: p.id, name: p.nickname, guestId: p.guest_id }))
+  interface Participant {
+    id: string
+    nickname: string
+    guest_id: string
+  }
+
+  const players = (participants || []).map((p: Participant) => ({
+    id: p.id,
+    name: p.nickname,
+    guestId: p.guest_id,
+  }))
 
   return NextResponse.json({ players })
 }


### PR DESCRIPTION
## Summary
- add explicit Participant interface in players API route

## Testing
- `npm test`
- `npm run lint` *(fails: next: not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'next' and 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68aa2e6e50f48327b42c0f9dc956a00f