### PR TITLE
fix(players-route): remove any casts and type list

### DIFF
--- a/src/app/api/games/[code]/players/route.ts
+++ b/src/app/api/games/[code]/players/route.ts
@@ -19,7 +19,7 @@ export async function GET(
   const { code } = await params
   const gameCode = String(code || '').toUpperCase()
 
-  const supabase = supabaseServer() as any
+  const supabase = supabaseServer()
 
   const { data: room } = await supabase
     .from('rooms')
@@ -45,7 +45,7 @@ export async function GET(
     .select('id, nickname, guest_id')
     .eq('session_id', session.id)
 
-  const participants = (participantData ?? []) as Participant[]
+  const participants: Participant[] = participantData ?? []
 
   const players = participants.map((p: Participant) => ({
     id: p.id,
@@ -73,7 +73,7 @@ export async function POST(
 
   const guestId = guestIdFromBody ?? randomUUID()
 
-  const supabase = supabaseServer() as any
+  const supabase = supabaseServer()
   const { data, error } = await supabase.rpc('join_room', {
     p_code: gameCode,
     p_nickname: playerName,


### PR DESCRIPTION
## Summary
- refactor players route to use typed supabase client and participants list

## Testing
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@radix-ui%2freact-accordion)*

------
https://chatgpt.com/codex/tasks/task_e_68aa352f667483279e950891eb220fb7