### PR TITLE
Pass request to getSession in game API routes

### DIFF
--- a/src/app/api/games/[code]/answers/route.ts
+++ b/src/app/api/games/[code]/answers/route.ts
@@ -11,13 +11,10 @@ interface AnswerBody {
   answer: 'A' | 'B' | 'C' | 'D' | null
 }
 
-export async function POST(
-  req: NextRequest,
-  { params }: { params: Promise<{ code: string }> }
-) {
-  const session = await getSession()
+export async function POST(req: NextRequest, context: any) {
+  const session = await getSession(req)
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = await params
+  const code = context?.params?.code as string
   const gameCode = String(code || '').toUpperCase()
   const game = store.getGame(gameCode)
   if (!game) return NextResponse.json({ error: 'Game not found' }, { status: 404 })

--- a/src/app/api/games/[code]/config/route.ts
+++ b/src/app/api/games/[code]/config/route.ts
@@ -1,5 +1,5 @@
 // PATH: src/app/api/games/[code]/config/route.ts
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { supabaseServer } from '@/integrations/supabase/server' // dôležitý import
 import { getSession } from '@/app/api/games/_session'
 
@@ -7,10 +7,10 @@ export const dynamic = 'force-dynamic'
 
 // (voliteľné) Načítanie aktuálnej konfigurácie hry
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function GET(_req: Request, { params }: any) {
-  const session = await getSession()
+export async function GET(req: NextRequest, context: any) {
+  const session = await getSession(req)
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = params as { code: string }
+  const code = context?.params?.code as string
 
   // Ak chceš, môžeš čítať z DB. Tu ponechám stub, aby build vždy prešiel.
   // try {
@@ -35,10 +35,10 @@ interface ConfigBody {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function POST(req: Request, { params }: any) {
-  const session = await getSession()
+export async function POST(req: NextRequest, context: any) {
+  const session = await getSession(req)
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = params as { code: string }
+  const code = context?.params?.code as string
 
   const body = (await req.json().catch(() => ({}))) as ConfigBody
 

--- a/src/app/api/games/[code]/leaderboard/route.ts
+++ b/src/app/api/games/[code]/leaderboard/route.ts
@@ -1,15 +1,15 @@
 // PATH: src/app/api/games/[code]/leaderboard/route.ts
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { store, type Player } from '@/lib/herdvote/store'
 import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function GET(_req: Request, { params }: any) {
-  const session = await getSession()
+export async function GET(req: NextRequest, context: any) {
+  const session = await getSession(req)
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = params as { code: string }
+  const code = context?.params?.code as string
   const gameCode = String(code || '').toUpperCase()
 
   const game = store.getGame(gameCode)

--- a/src/app/api/games/[code]/lock-lobby/route.ts
+++ b/src/app/api/games/[code]/lock-lobby/route.ts
@@ -1,14 +1,14 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { getSession } from '@/app/api/games/_session'
 import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
-export async function POST(_req: Request) {
-  const session = await getSession()
+export async function POST(req: NextRequest, _context: any) {
+  const session = await getSession(req)
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const supabase = supabaseServer(session.access_token)
+  const supabase = supabaseServer()
   const { data, error } = await supabase.rpc('lock_lobby')
   if (error || !data) {
     return NextResponse.json(

--- a/src/app/api/games/[code]/rounds/[roundId]/question/route.ts
+++ b/src/app/api/games/[code]/rounds/[roundId]/question/route.ts
@@ -1,5 +1,5 @@
 // PATH: src/app/api/games/[code]/rounds/[roundId]/question/route.ts
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { store, type Question } from '@/lib/herdvote/store'
 import { getSession } from '@/app/api/games/_session'
 
@@ -8,10 +8,11 @@ export const dynamic = 'force-dynamic'
 type FourAnswers = { answer_a?: string; answer_b?: string; answer_c?: string; answer_d?: string }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function GET(_req: Request, { params }: any) {
-  const session = await getSession()
+export async function GET(req: NextRequest, context: any) {
+  const session = await getSession(req)
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code, roundId } = params as { code: string; roundId: string }
+  const code = context?.params?.code as string
+  const roundId = context?.params?.roundId as string
   const gameCode = String(code || '').toUpperCase()
 
   const game = store.getGame(gameCode)
@@ -20,7 +21,7 @@ export async function GET(_req: Request, { params }: any) {
   const round = game.rounds.find(r => r.id === roundId)
   if (!round) return NextResponse.json({ error: 'Round not found' }, { status: 404 })
 
-  const url = new URL(_req.url)
+  const url = new URL(req.url)
   const qIndexParam = url.searchParams.get('qIndex')
   const qIndex = qIndexParam ? parseInt(qIndexParam, 10) : (round.qIndex || 0)
 

--- a/src/app/api/games/[code]/rounds/lock/route.ts
+++ b/src/app/api/games/[code]/rounds/lock/route.ts
@@ -1,5 +1,5 @@
 // PATH: src/app/api/games/[code]/rounds/lock/route.ts
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { store } from '@/lib/herdvote/store'
 import { RealtimeServer } from '@/lib/realtime/server'
 import { channelFor } from '@/lib/realtime/types'
@@ -8,10 +8,10 @@ import { getSession } from '@/app/api/games/_session'
 export const dynamic = 'force-dynamic'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function POST(req: Request, { params }: any) {
-  const session = await getSession()
+export async function POST(req: NextRequest, context: any) {
+  const session = await getSession(req)
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = params as { code: string }
+  const code = context?.params?.code as string
   const gameCode = String(code || '').toUpperCase()
 
   const game = store.getGame(gameCode)

--- a/src/app/api/games/[code]/rounds/next/route.ts
+++ b/src/app/api/games/[code]/rounds/next/route.ts
@@ -1,5 +1,5 @@
 // PATH: src/app/api/games/[code]/rounds/next/route.ts
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { store, type Player } from '@/lib/herdvote/store'
 import { RealtimeServer } from '@/lib/realtime/server'
 import { channelFor } from '@/lib/realtime/types'
@@ -10,10 +10,10 @@ export const dynamic = 'force-dynamic'
 interface NextBody { roundId?: string }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function POST(req: Request, { params }: any) {
-  const session = await getSession()
+export async function POST(req: NextRequest, context: any) {
+  const session = await getSession(req)
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = params as { code: string }
+  const code = context?.params?.code as string
   const gameCode = String(code || '').toUpperCase()
 
   const game = store.getGame(gameCode)

--- a/src/app/api/games/[code]/rounds/results/route.ts
+++ b/src/app/api/games/[code]/rounds/results/route.ts
@@ -1,5 +1,5 @@
 // PATH: src/app/api/games/[code]/rounds/results/route.ts
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { store, type Player } from '@/lib/herdvote/store'
 import { RealtimeServer } from '@/lib/realtime/server'
 import { channelFor } from '@/lib/realtime/types'
@@ -11,10 +11,10 @@ export const dynamic = 'force-dynamic'
 interface ResultsBody { roundId?: string }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function POST(req: Request, { params }: any) {
-  const session = await getSession()
+export async function POST(req: NextRequest, context: any) {
+  const session = await getSession(req)
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = params as { code: string }
+  const code = context?.params?.code as string
   const gameCode = String(code || '').toUpperCase()
 
   const game = store.getGame(gameCode)

--- a/src/app/api/games/[code]/rounds/route.ts
+++ b/src/app/api/games/[code]/rounds/route.ts
@@ -1,5 +1,5 @@
 // PATH: src/app/api/games/[code]/rounds/route.ts
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { store, type RoundSettings } from '@/lib/herdvote/store'
 import { getSession } from '@/app/api/games/_session'
 
@@ -21,10 +21,10 @@ interface RoundBody {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function POST(req: Request, { params }: any) {
-  const session = await getSession()
+export async function POST(req: NextRequest, context: any) {
+  const session = await getSession(req)
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = params as { code: string }
+  const code = context?.params?.code as string
   const gameCode = String(code || '').toUpperCase()
 
   const game = store.getGame(gameCode)

--- a/src/app/api/games/[code]/rounds/start/route.ts
+++ b/src/app/api/games/[code]/rounds/start/route.ts
@@ -1,5 +1,5 @@
 // PATH: src/app/api/games/[code]/rounds/start/route.ts
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { store } from '@/lib/herdvote/store'
 import { RealtimeServer } from '@/lib/realtime/server'
 import { channelFor } from '@/lib/realtime/types'
@@ -10,10 +10,10 @@ export const dynamic = 'force-dynamic'
 interface StartBody { roundId?: string }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function POST(req: Request, { params }: any) {
-  const session = await getSession()
+export async function POST(req: NextRequest, context: any) {
+  const session = await getSession(req)
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = params as { code: string }
+  const code = context?.params?.code as string
 
   const gameCode = String(code || '').toUpperCase()
   const game = store.getGame(gameCode)

--- a/src/app/api/games/[code]/rounds/timer/start/route.ts
+++ b/src/app/api/games/[code]/rounds/timer/start/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { store } from '@/lib/herdvote/store'
 import { RealtimeServer } from '@/lib/realtime/server'
 import { channelFor } from '@/lib/realtime/types'
@@ -10,10 +10,10 @@ export const dynamic = 'force-dynamic'
 interface TimerBody { seconds?: number; duration?: number; roundId?: string }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function POST(req: Request, { params }: any) {
-  const session = await getSession()
+export async function POST(req: NextRequest, context: any) {
+  const session = await getSession(req)
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = params as { code: string }
+  const code = context?.params?.code as string
   const gameCode = String(code || '').toUpperCase()
 
   const game = store.getGame(gameCode)

--- a/src/app/api/games/[code]/route.ts
+++ b/src/app/api/games/[code]/route.ts
@@ -1,14 +1,14 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { getSession } from '@/app/api/games/_session'
 import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function GET(_req: Request, { params }: any) {
-  const session = await getSession()
+export async function GET(req: NextRequest, context: any) {
+  const session = await getSession(req)
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = params as { code: string }
+  const code = context?.params?.code as string
 
   const gameCode = String(code || '').toUpperCase()
   const supabase = supabaseServer() as any

--- a/src/app/api/games/[code]/start/route.ts
+++ b/src/app/api/games/[code]/start/route.ts
@@ -1,14 +1,14 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { getSession } from '@/app/api/games/_session'
 import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
-export async function POST(_req: Request) {
-  const session = await getSession()
+export async function POST(req: NextRequest, _context: any) {
+  const session = await getSession(req)
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const supabase = supabaseServer(session.access_token)
+  const supabase = supabaseServer()
 
   const { data, error } = await supabase.rpc('start_game')
   if (error || !data) {

--- a/src/app/api/games/_session.ts
+++ b/src/app/api/games/_session.ts
@@ -1,46 +1,29 @@
-import 'server-only'
 import { NextRequest } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 
-const SUPABASE_URL =
-  process.env.NEXT_PUBLIC_SUPABASE_URL ||
-  process.env.SUPABASE_URL ||
-  ''
-
-const SUPABASE_ANON_KEY =
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
+const SUPABASE_PUBLISHABLE_KEY =
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
-  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ||
-  process.env.SUPABASE_ANON_KEY ||
+  process.env.NEXT_PUBLIC_SUPABASE_KEY ||
   ''
 
-export type SessionInfo = {
-  token: string
-  userId: string
-  email?: string | null
-} | null
+export type SessionUser = { id: string; email?: string | null }
+export type Session = { user: SessionUser } | null
 
-export async function getSession(req: NextRequest): Promise<SessionInfo> {
-  const auth = req.headers.get('authorization') || req.headers.get('Authorization')
-  const tokenFromHeader = auth?.startsWith('Bearer ') ? auth.slice(7) : undefined
+/**
+ * Vyberie bearer token z Authorization hlavičky alebo cookie 'sb-access-token'
+ * a cez Supabase zistí aktuálneho používateľa.
+ */
+export async function getSession(req: NextRequest): Promise<Session> {
+  const authHeader = req.headers.get('authorization') || req.headers.get('Authorization')
+  const bearer = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined
+  const cookieToken = req.cookies.get('sb-access-token')?.value
+  const token = bearer || cookieToken
+  if (!token || !SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY) return null
 
-  const cookieToken =
-    req.cookies.get('sb-access-token')?.value ??
-    req.cookies.get('supabase-auth-token')?.value
-
-  const token = tokenFromHeader || cookieToken
-  if (!token || !SUPABASE_URL || !SUPABASE_ANON_KEY) return null
-
-  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
-    auth: { persistSession: false, autoRefreshToken: false },
-  })
-
+  const supabase = createClient(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY)
   const { data, error } = await supabase.auth.getUser(token)
   if (error || !data?.user) return null
 
-  return { token, userId: data.user.id, email: data.user.email }
-}
-
-export function getBearerToken(req: NextRequest): string | null {
-  const auth = req.headers.get('authorization') || req.headers.get('Authorization')
-  return auth?.startsWith('Bearer ') ? auth.slice(7) : null
+  return { user: { id: data.user.id, email: data.user.email } }
 }

--- a/src/app/api/games/route.ts
+++ b/src/app/api/games/route.ts
@@ -1,9 +1,9 @@
 // PATH: src/app/api/games/route.ts
 // Create game: POST /api/games  ->  { gameCode }
 
-import { NextRequest, NextResponse } from 'next/server';
-import { getSession } from '@/app/api/games/_session';
-import { supabaseServer } from '@/integrations/supabase/server';
+import { NextRequest, NextResponse } from 'next/server'
+import { getSession } from '@/app/api/games/_session'
+import { supabaseServer } from '@/integrations/supabase/server'
 
 /**
  * Example (unauthenticated):
@@ -13,21 +13,24 @@ import { supabaseServer } from '@/integrations/supabase/server';
 
 export const dynamic = 'force-dynamic';
 
-export async function POST(_req: NextRequest) {
-  const session = await getSession();
-  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+export async function POST(req: NextRequest, _context: any) {
+  const session = await getSession(req)
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const supabase = supabaseServer(session.access_token);
+  const supabase = supabaseServer()
 
-  const { data: room, error } = await supabase.rpc('ensure_room');
+  const { data: room, error } = await supabase.rpc('ensure_room')
   if (error || !room) {
-    return NextResponse.json({ error: error?.message || 'Failed to ensure room' }, { status: 500 });
+    return NextResponse.json(
+      { error: error?.message || 'Failed to ensure room' },
+      { status: 500 }
+    )
   }
 
-  const { error: lobbyError } = await supabase.rpc('open_lobby');
+  const { error: lobbyError } = await supabase.rpc('open_lobby')
   if (lobbyError) {
-    return NextResponse.json({ error: lobbyError.message }, { status: 500 });
+    return NextResponse.json({ error: lobbyError.message }, { status: 500 })
   }
 
-  return NextResponse.json({ gameCode: room.code });
+  return NextResponse.json({ gameCode: room.code })
 }


### PR DESCRIPTION
## Summary
- replace game session helper with explicit `getSession(req: NextRequest)` implementation
- update game API routes to accept `(req, context)` and forward request to `getSession`
- drop use of session access tokens when creating Supabase clients

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find type definition file for 'next' and 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68aa4df764dc8327979ecac2308cc536