### PR TITLE
fix: allow dictionaries without apps key

### DIFF
--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -30,6 +30,6 @@ export interface AppsDictionary {
 }
 
 export interface Dictionary {
-  apps: AppsDictionary
+  apps?: AppsDictionary
   [key: string]: unknown
 }


### PR DESCRIPTION
## Summary
- allow i18n dictionaries to omit the `apps` key so locale JSONs without that section compile

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'next')*

------
https://chatgpt.com/codex/tasks/task_e_68aafd7b61048327b2aef2945259ddf9