### PR TITLE
fix: guard apps dictionary in app pages

### DIFF
--- a/src/app/[lang]/apps/couplesync/Client.tsx
+++ b/src/app/[lang]/apps/couplesync/Client.tsx
@@ -24,8 +24,10 @@ function MagicLinkButton({ lang, label }: { lang: string; label: string }) {
 }
 
 export default function Client({ dict, lang }: Props) {
-  const cs = dict.apps.games.couplesync
-  const back = dict.apps.games.ctaBack
+  const apps = dict.apps
+  if (!apps) return null
+  const cs = apps.games.couplesync
+  const back = apps.games.ctaBack
   return (
     <div className="mx-auto max-w-4xl px-4 py-10 space-y-16">
       <Link

--- a/src/app/[lang]/apps/hadacka/page.tsx
+++ b/src/app/[lang]/apps/hadacka/page.tsx
@@ -13,8 +13,10 @@ export default async function HadackaPage({ params }: P) {
   const lang = normalizeUrlLocale(raw)
   if (!SUPPORTED_LOCALES.includes(lang as Locale)) notFound()
   const dict = await getDictionary(lang as Locale)
-  const game = dict.apps.games.hadacka
-  const back = dict.apps.games.ctaBack
+  const apps = dict.apps
+  if (!apps) notFound()
+  const game = apps.games.hadacka
+  const back = apps.games.ctaBack
 
   return (
     <div className="space-y-8">

--- a/src/app/[lang]/apps/page.tsx
+++ b/src/app/[lang]/apps/page.tsx
@@ -16,6 +16,7 @@ export default async function AppsPage({ params }: P) {
   if (!SUPPORTED_LOCALES.includes(lang as Locale)) notFound()
   const dict = await getDictionary(lang as Locale)
   const apps = dict.apps
+  if (!apps) notFound()
   const games = apps.games
   const categories = [
     { key: 'quizzes', slugs: ['quiz'] },

--- a/src/app/[lang]/apps/quiz/Client.tsx
+++ b/src/app/[lang]/apps/quiz/Client.tsx
@@ -12,8 +12,10 @@ type Props = {
 
 export default function QuizPageClient({ dict, lang }: Props) {
   const { user, loading } = useAuth()
-  const game = dict.apps.games.quiz
-  const back = dict.apps.games.ctaBack
+  const apps = dict.apps
+  if (!apps) return null
+  const game = apps.games.quiz
+  const back = apps.games.ctaBack
 
   return (
     <div className="space-y-8">


### PR DESCRIPTION
## Summary
- ensure `dict.apps` exists before accessing game text in Hadacka page and apps list
- add client-side guards for quiz and couplesync pages

## Testing
- `npm test`
- `npm run build` *(fails: next not found)
- `npm install` *(fails: 403 for @radix-ui/react-accordion)*

------
https://chatgpt.com/codex/tasks/task_e_68aaffcddea48327984eaf1a540de72c