### PR TITLE
Remove redundant re-export block causing build error

### DIFF
--- a/src/lib/herdvote/store.ts
+++ b/src/lib/herdvote/store.ts
@@ -153,15 +153,3 @@ export const store = {
 };
 
 export default store;
-
-export type {
-  Player,
-  Question,
-  ScoringClassic,
-  ScoringPodium,
-  RoundSettings,
-  Round,
-  PlayerAnswer,
-  Game,
-  GameSettings,
-};


### PR DESCRIPTION
## Summary
- fix duplicate type exports in `src/lib/herdvote/store.ts`

## Testing
- `npm test`
- `npm run lint` *(fails: next: not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'next')*

------
https://chatgpt.com/codex/tasks/task_e_68ab025d91948327891789e46de32437