### PR TITLE
fix: remove duplicate RealtimeClient window declaration

### DIFF
--- a/src/lib/realtime/client.ts
+++ b/src/lib/realtime/client.ts
@@ -3,12 +3,6 @@
 import type { HerdEvent, RealtimeCallback } from './types'
 import { log } from '../logger'
 
-declare global {
-  interface Window {
-    RealtimeClient?: RealtimeClientImpl
-  }
-}
-
 class RealtimeClientImpl {
   private subscribers = new Map<string, Set<RealtimeCallback>>()
   private isConnected = false


### PR DESCRIPTION
## Summary
- remove redundant `Window.RealtimeClient` declaration in realtime client to avoid conflicting global type

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find type definition file for 'next' and 'node')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab045c39a88327b1376717d0701368