### PR TITLE
fix: safeguard simulateEvent invocation

### DIFF
--- a/src/lib/realtime/server.ts
+++ b/src/lib/realtime/server.ts
@@ -29,8 +29,10 @@ class RealtimeServerImpl {
     if (typeof window !== 'undefined') {
       // Browser context - send to client directly
       const client = window.RealtimeClient
-      if (client?.simulateEvent) {
-        setTimeout(() => client.simulateEvent(channel, event), 50)
+      const simulate = client?.simulateEvent
+
+      if (simulate) {
+        setTimeout(() => simulate(channel, event), 50)
       }
     } else {
       // Server context - for production we'd publish to external service


### PR DESCRIPTION
## Summary
- ensure realtime fallback guards simulateEvent before calling

## Testing
- `npm test`
- `npm run typecheck` *(fails: Cannot find type definition file for 'next' and 'node'; `npm install` failed with 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab07c89c24832795be136caf772a01