### PR TITLE
fix: prevent useTheme server error in Toaster

### DIFF
--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useTheme } from "next-themes"
 import { Toaster as Sonner, toast } from "sonner"
 


### PR DESCRIPTION
## Summary
- mark `Toaster` component as client so it can safely use `useTheme`

## Testing
- `npm test`
- `npm run build` *(fails: next: not found; attempted `npm install` but received 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0c42b0d48327ad720be6ba087df1