### PR TITLE
fix: use dictionary links for apps

### DIFF
--- a/src/app/[lang]/apps/page.tsx
+++ b/src/app/[lang]/apps/page.tsx
@@ -53,6 +53,9 @@ export default async function AppsPage({ params }: P) {
             <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
               {cat.slugs.map((slug) => {
                 const g = games[slug] as GameEntry
+                const href = g.link.startsWith('http')
+                  ? g.link
+                  : `/${lang}${g.link}`
                 return (
                   <Card key={slug}>
                     <Image
@@ -68,7 +71,7 @@ export default async function AppsPage({ params }: P) {
                     </CardHeader>
                     <CardContent>
                       <Button asChild className="w-full">
-                        <Link href={`/${lang}/apps/${slug}`}>{g.cta}</Link>
+                        <Link href={href}>{g.cta}</Link>
                       </Button>
                     </CardContent>
                   </Card>


### PR DESCRIPTION
## Summary
- respect `link` property from translation data when building app links

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab30ee57008327bc899f1134562e69