### PR TITLE
Display category names in Hadacka rounds

### DIFF
--- a/src/components/hadacka/WordCard.tsx
+++ b/src/components/hadacka/WordCard.tsx
@@ -83,7 +83,7 @@ export function WordCard({
               {word.word}
             </h1>
             <p className="text-muted-foreground capitalize">
-              {word.categoryCode.replace('-', ' ')}
+              {(word.categoryName || word.categoryCode).replace('-', ' ')}
             </p>
           </div>
 

--- a/src/lib/services/wordService.ts
+++ b/src/lib/services/wordService.ts
@@ -5,7 +5,7 @@ export class WordService {
   static async getWordsByCategories(categories: string[]): Promise<WordVM[]> {
     const query = supabase
       .from('had_words')
-      .select('id, word, category_code, difficulty_level, mode_code')
+      .select('id, word, category_code, difficulty_level, mode_code, category:had_categories(name)')
     if (categories && categories.length > 0) {
       query.in('category_code', categories)
     }
@@ -15,6 +15,7 @@ export class WordService {
       id: String(w.id),
       word: w.word as string,
       categoryCode: w.category_code as string,
+      categoryName: ((w as any).category?.name as string) || undefined,
       difficultyLevel: w.difficulty_level as number,
       modeCode: w.mode_code as string,
     }))

--- a/src/types/hadacka.ts
+++ b/src/types/hadacka.ts
@@ -2,6 +2,7 @@ export interface WordVM {
   id: string
   word: string
   categoryCode: string
+  categoryName?: string
   difficultyLevel: number
   modeCode: string
 }


### PR DESCRIPTION
## Summary
- fetch category names for words from Supabase
- extend word model with optional categoryName
- show category name on game word card

## Testing
- `npm test` *(fails: vitest not found)*
- `npx vitest` *(fails: 403 Forbidden when retrieving package)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4a8297a8832788b6247ef1271bb9