### PR TITLE
Fix game retrieval and round setup API routes

### DIFF
--- a/src/app/api/games/[code]/rounds/config/route.ts
+++ b/src/app/api/games/[code]/rounds/config/route.ts
@@ -13,7 +13,7 @@ export async function POST(req: Request, context: any) {
 
   // bezpečné načítanie body
   const body = await req.json().catch(() => ({} as any))
-  const { index, categoryId, questions } = body
+  const { index, categoryId, questions, prepSeconds, questionSeconds, scoringMode } = body
 
   const s = supabaseServer(session.access_token) as any // "as any" obíde TS typy generované zo Supabase
 
@@ -26,12 +26,18 @@ export async function POST(req: Request, context: any) {
         idx: index,
         category: categoryId,
         count: questions,
+        prep_seconds: prepSeconds,
+        question_seconds: questionSeconds,
+        scoring_mode: scoringMode,
         status: 'setup',
       },
       { onConflict: 'game_code,idx' }
     )
 
   if (error) return NextResponse.json({ error: error.message }, { status: 400 })
+
+  // udržujeme phase v herd_games
+  await s.from('herd_games').update({ phase: 'round_setup' }).eq('code', code)
 
   // voliteľne: ak je to posledné potvrdené kolo, prepneme hru do "ready"
   try {
@@ -48,5 +54,5 @@ export async function POST(req: Request, context: any) {
     // nič – len nech to nepadne, keď typy/kolónky chýbajú
   }
 
-  return NextResponse.json({ ok: true })
+  return NextResponse.json({ ok: true, phase: 'round_setup', savedIndex: index })
 }

--- a/src/app/api/games/[code]/route.ts
+++ b/src/app/api/games/[code]/route.ts
@@ -4,36 +4,43 @@ import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
-export async function GET(_req: Request, context: any) {
+export async function GET(_req: Request, { params }: { params: { code: string } }) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const { code } = (context?.params ?? {}) as { code: string }
 
-  const gameCode = String(code || '').toUpperCase()
-  const supabase = supabaseServer(session.access_token)
+  const code = String(params.code || '').toUpperCase()
+  const s = supabaseServer(session.access_token)
 
-  const { data: game, error: gameErr } = await supabase
+  const { data: game, error } = await s
     .from('herd_games')
-    .select('code, phase, total_rounds, active_round_index')
-    .eq('code', gameCode)
+    .select('code, phase, total_rounds, active_round_index, lobby_locked')
+    .eq('code', code)
     .eq('owner_id', session.user.id)
     .single()
 
-  if (gameErr || !game) {
-    return NextResponse.json({ error: 'Game not found' }, { status: 404 })
+  if (error || !game) {
+    return NextResponse.json('Game not found', { status: 404 })
   }
 
-  const { count: roundsCount } = await supabase
+  const { count: roundsCount } = await s
     .from('herd_rounds')
     .select('idx', { count: 'exact', head: true })
-    .eq('game_code', gameCode)
+    .eq('game_code', code)
+
+  const phase =
+    game.phase === 'setup'
+      ? 'config'
+      : game.phase === 'running'
+        ? 'playing'
+        : game.phase === 'ended'
+          ? 'final'
+          : (game.phase as any) ?? 'lobby'
 
   return NextResponse.json({
     code: game.code,
-    phase: game.phase ?? 'lobby',
-    total_rounds: game.total_rounds ?? 0,
+    phase,
+    lobby_locked: !!game.lobby_locked,
+    total_rounds: game.total_rounds ?? roundsCount ?? 0,
     active_round_index: game.active_round_index ?? 0,
-    roundsCount: roundsCount ?? 0,
-    playersCount: 0,
   })
 }


### PR DESCRIPTION
## Summary
- normalize game phase and expose lobby lock in `/api/games/[code]`
- persist full round configuration and mark game phase

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5bc28a188327a4da5b6216dd92d3