### PR TITLE
fix: clear game code without null

### DIFF
--- a/src/app/[lang]/apps/herd-vote/AdminWizard.tsx
+++ b/src/app/[lang]/apps/herd-vote/AdminWizard.tsx
@@ -158,7 +158,7 @@ export default function AdminWizard({ code: codeProp }: { code?: string }) {
     try {
       const r = await authFetch(`/api/games/${code}/end`, { method: 'POST' })
       if (!r.ok) throw new Error(await r.text())
-      setCode(null)
+      setCode('')
       setGame(null)
       setTotalRounds(3)
       setPrepSec(10)


### PR DESCRIPTION
## Summary
- avoid passing null to setCode when ending a game

## Testing
- ⚠️ `npm test` *(vitest: not found)*
- ⚠️ `npm run lint` *(next: not found)*
- ⚠️ `npm run build` *(next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac67bf11408327986148c57312d843