### PR TITLE
fix build error in herd-vote categories API

### DIFF
--- a/src/app/api/herd-vote/categories/route.ts
+++ b/src/app/api/herd-vote/categories/route.ts
@@ -14,7 +14,7 @@ export async function GET() {
     .order('name', { ascending: true })
 
 
-  if (error || !cats) {
+  if (error || !data) {
     return NextResponse.json({ categories: [] })
 
   }


### PR DESCRIPTION
## Summary
- check fetched category data instead of undefined variable

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6b6d8e748327999885fbbf141059