### PR TITLE
fix: correct route context typing

### DIFF
--- a/src/app/api/games/[code]/answers/route.ts
+++ b/src/app/api/games/[code]/answers/route.ts
@@ -5,9 +5,9 @@ export const dynamic = 'force-dynamic'
 
 export async function POST(
   req: Request,
-  ctx: { params: Record<string, string | string[]> }
+  ctx: { params: { code: string } }
 ) {
-  const code = String(ctx.params?.code || '').toUpperCase()
+  const code = ctx.params.code.toUpperCase()
 
   const body = await req.json().catch(() => ({})) as {
     playerId?: string


### PR DESCRIPTION
## Summary
- fix API route POST signature to use concrete route params type

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8f1035dc8327aca5c3bba9658ce4