### PR TITLE
fix: update answers route context for Next.js 15

### DIFF
--- a/src/app/api/games/[code]/answers/route.ts
+++ b/src/app/api/games/[code]/answers/route.ts
@@ -5,9 +5,9 @@ export const dynamic = 'force-dynamic'
 
 export async function POST(
   req: Request,
-  ctx: { params: { code: string } }
+  ctx: { params: Record<string, string | string[]> }
 ) {
-  const code = ctx.params.code.toUpperCase()
+  const code = String(ctx.params?.code || '').toUpperCase()
 
   const body = await req.json().catch(() => ({})) as {
     playerId?: string


### PR DESCRIPTION
## Summary
- adjust /api/games/[code]/answers route handler context to Next.js 15 requirement

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac91ba292c8327b55cb85f0a16c52a