### PR TITLE
fix: align quiz API route params with Next.js typings

### DIFF
--- a/src/app/api/games/[code]/answers/route.ts
+++ b/src/app/api/games/[code]/answers/route.ts
@@ -5,9 +5,9 @@ export const dynamic = 'force-dynamic'
 
 export async function POST(
   req: Request,
-  ctx: { params: Record<string, string | string[]> }
+  { params }: { params: { code: string } }
 ) {
-  const code = String(ctx.params?.code || '').toUpperCase()
+  const code = params.code.toUpperCase()
 
   const body = await req.json().catch(() => ({})) as {
     playerId?: string

--- a/src/app/api/games/[code]/config/route.ts
+++ b/src/app/api/games/[code]/config/route.ts
@@ -8,11 +8,11 @@ export const dynamic = 'force-dynamic'
 // Načítanie aktuálnej konfigurácie hry
 export async function GET(
   _req: Request,
-  ctx: { params: Record<string, string | string[]> }
+  { params }: { params: { code: string } }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const code = String(ctx.params?.code || '')
+  const code = params.code
 
   const s = supabaseServer(session.access_token)
   const { data, error } = await s
@@ -41,11 +41,11 @@ export async function GET(
 // Uloženie / update konfigurácie hry
 export async function POST(
   req: Request,
-  ctx: { params: Record<string, string | string[]> }
+  { params }: { params: { code: string } }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const code = String(ctx.params?.code || '')
+  const code = params.code
 
   const body = await req.json().catch(() => ({} as any))
   const totalRounds =

--- a/src/app/api/games/[code]/end/route.ts
+++ b/src/app/api/games/[code]/end/route.ts
@@ -6,12 +6,12 @@ export const dynamic = 'force-dynamic'
 
 export async function POST(
   _req: Request,
-  ctx: { params: Record<string, string | string[]> }
+  { params }: { params: { code: string } }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const gameCode = String(ctx.params?.code || '').toUpperCase()
+  const gameCode = params.code.toUpperCase()
 
   const supabase = supabaseServer(session.access_token)
 

--- a/src/app/api/games/[code]/leaderboard/route.ts
+++ b/src/app/api/games/[code]/leaderboard/route.ts
@@ -7,13 +7,12 @@ export const dynamic = 'force-dynamic'
 
 export async function GET(
   _req: Request,
-  ctx: { params: Record<string, string | string[]> }
-
-  ) {
+  { params }: { params: { code: string } }
+) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const code = String(ctx.params?.code || '').toUpperCase()
+  const code = params.code.toUpperCase()
 
   const s = supabaseServer(session.access_token)
 

--- a/src/app/api/games/[code]/players/route.ts
+++ b/src/app/api/games/[code]/players/route.ts
@@ -15,9 +15,9 @@ type Participant = {
 // GET – vráti lobby (zoznam hráčov)
 export async function GET(
   _req: Request,
-  ctx: { params: Record<string, string | string[]> }
+  { params }: { params: { code: string } }
 ) {
-  const gameCode = String(ctx.params?.code || '').toUpperCase()
+  const gameCode = params.code.toUpperCase()
 
   const supabase = supabaseServer()
 
@@ -59,9 +59,9 @@ export async function GET(
 // POST – pridá hráča (kým je lobby otvorená)
 export async function POST(
   req: Request,
-  ctx: { params: Record<string, string | string[]> }
+  { params }: { params: { code: string } }
 ) {
-  const gameCode = String(ctx.params?.code || '').toUpperCase()
+  const gameCode = params.code.toUpperCase()
 
   const body = (await req.json().catch(() => ({}))) as {
     name?: string

--- a/src/app/api/games/[code]/rounds/[roundId]/question/route.ts
+++ b/src/app/api/games/[code]/rounds/[roundId]/question/route.ts
@@ -12,12 +12,11 @@ type FourAnswers = {
 }
 
 export async function GET(
-    req: Request,
-    ctx: { params: Record<string, string | string[]> }
-  ) {
-    const code = String(ctx.params?.code || '').toUpperCase()
-    const roundId = String(ctx.params?.roundId || '')
-n
+  req: Request,
+  { params }: { params: { code: string; roundId: string } }
+) {
+  const code = params.code.toUpperCase()
+  const roundId = params.roundId
 
   const url = new URL(req.url)
   const qIndexParam = url.searchParams.get('qIndex')

--- a/src/app/api/games/[code]/rounds/config/route.ts
+++ b/src/app/api/games/[code]/rounds/config/route.ts
@@ -7,9 +7,9 @@ export const dynamic = 'force-dynamic'
 
 export async function POST(
   req: Request,
-  ctx: { params: Record<string, string | string[]> }
+  { params }: { params: { code: string } }
 ) {
-  const rawCode = String(ctx.params?.code || '')
+  const rawCode = params.code
 
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })

--- a/src/app/api/games/[code]/rounds/lock/route.ts
+++ b/src/app/api/games/[code]/rounds/lock/route.ts
@@ -9,12 +9,12 @@ export const dynamic = 'force-dynamic'
 
 export async function POST(
   req: Request,
-  ctx: { params: Record<string, string | string[]> }
+  { params }: { params: { code: string } }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const code = String(ctx.params?.code || '').toUpperCase()
+  const code = params.code.toUpperCase()
   const body = await req.json().catch(() => ({})) as { roundId?: string }
 
   const s = supabaseServer(session.access_token)

--- a/src/app/api/games/[code]/rounds/next/route.ts
+++ b/src/app/api/games/[code]/rounds/next/route.ts
@@ -7,14 +7,14 @@ import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-  export async function POST(
-    req: Request,
-    ctx: { params: Record<string, string | string[]> }
-  ) {
+export async function POST(
+  req: Request,
+  { params }: { params: { code: string } }
+) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-    const code = String(ctx.params?.code || '').toUpperCase()
+  const code = params.code.toUpperCase()
 
   const body = await req.json().catch(() => ({})) as { roundId?: string }
   const s = supabaseServer(session.access_token)

--- a/src/app/api/games/[code]/rounds/results/route.ts
+++ b/src/app/api/games/[code]/rounds/results/route.ts
@@ -8,14 +8,13 @@ import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-  export async function POST(
-    req: Request,
-    ctx: { params: Record<string, string | string[]> }
-  ) {
+export async function POST(
+  req: Request,
+  { params }: { params: { code: string } }
+) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-
-    const code = String(ctx.params?.code || '').toUpperCase()
+  const code = params.code.toUpperCase()
 
   const body = await req.json().catch(() => ({})) as { roundId?: string }
 

--- a/src/app/api/games/[code]/rounds/route.ts
+++ b/src/app/api/games/[code]/rounds/route.ts
@@ -16,12 +16,12 @@ export const dynamic = 'force-dynamic'
  * }
  */
 export async function POST(
-    req: Request,
-    ctx: { params: Record<string, string | string[]> }
-  ) {
-    const session = await getSession()
-    if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    const gameCode = String(ctx.params?.code || '').toUpperCase()
+  req: Request,
+  { params }: { params: { code: string } }
+) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const gameCode = params.code.toUpperCase()
 
   const supabase = supabaseServer(session.access_token)
 

--- a/src/app/api/games/[code]/rounds/start/route.ts
+++ b/src/app/api/games/[code]/rounds/start/route.ts
@@ -6,12 +6,12 @@ import { getSession } from '@/app/api/games/_session'
 export const dynamic = 'force-dynamic'
 
 export async function POST(
-    req: Request,
-    ctx: { params: Record<string, string | string[]> }
-  ) {
+  req: Request,
+  { params }: { params: { code: string } }
+) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    const code = String(ctx.params?.code || '')
+  const code = params.code
 
   const body = await req.json().catch(() => ({} as any))
   const index = typeof body?.index === 'number' ? body.index : 0

--- a/src/app/api/games/[code]/rounds/timer/start/route.ts
+++ b/src/app/api/games/[code]/rounds/timer/start/route.ts
@@ -7,14 +7,13 @@ import { getSession } from '@/app/api/games/_session'
 export const dynamic = 'force-dynamic'
 
 export async function POST(
-    req: Request,
-    ctx: { params: Record<string, string | string[]> }
-
-  ) {
+  req: Request,
+  { params }: { params: { code: string } }
+) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-    const code = String(ctx.params?.code || '').toUpperCase()
+  const code = params.code.toUpperCase()
 
   const body = await req.json().catch(() => ({})) as {
     seconds?: number

--- a/src/app/api/games/[code]/route.ts
+++ b/src/app/api/games/[code]/route.ts
@@ -6,9 +6,9 @@ export const dynamic = 'force-dynamic'
 
 export async function GET(
   _req: Request,
-  ctx: { params: Record<string, string | string[]> }
+  { params }: { params: { code: string } }
 ) {
-  const rawCode = String(ctx.params?.code || '')
+  const rawCode = params.code
 
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })


### PR DESCRIPTION
## Summary
- fix Next.js `params` typings across quiz game API routes
- remove stray character in round question endpoint

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9324539883278418dec4e88e5af0