### PR TITLE
Prevent missing herd game records causing 404s

### DIFF
--- a/src/app/[lang]/apps/herd-vote/page.tsx
+++ b/src/app/[lang]/apps/herd-vote/page.tsx
@@ -322,7 +322,28 @@ export default function HerdVoteAdminPage() {
                     className="w-full border rounded px-3 py-2"
                   />
                   <button
-                    onClick={() => setTotalRounds(roundInput)}
+                    onClick={async () => {
+                      try {
+                        const r = await authFetch(`/api/games/${gameCode}/config`, {
+                          method: 'POST',
+                          headers: { 'Content-Type': 'application/json' },
+                          body: JSON.stringify({
+                            totalRounds: roundInput,
+                            prepSeconds: timeLimit,
+                            questionSeconds: timeLimit,
+                            scoringMode: mode === 'classic' ? 'simple' : 'weighted',
+                          }),
+                        })
+                        const j = await r.json()
+                        if (r.ok && j?.ok) {
+                          setTotalRounds(roundInput)
+                        } else {
+                          alert(j.error || 'Nepodarilo sa uložiť konfiguráciu')
+                        }
+                      } catch {
+                        alert('Nepodarilo sa uložiť konfiguráciu')
+                      }
+                    }}
                     className="px-4 py-2 rounded bg-blue-600 text-white"
                   >
                     Potvrdiť

--- a/src/app/api/games/[code]/rounds/route.ts
+++ b/src/app/api/games/[code]/rounds/route.ts
@@ -24,14 +24,19 @@ export async function POST(req: Request, ctx: any) {
 
   const supabase = supabaseServer(session.access_token)
 
-  const { data: game, error: gameErr } = await supabase
+  const { data: game } = await supabase
     .from('herd_games')
     .select('code')
     .eq('code', gameCode)
-    .single()
+    .maybeSingle()
 
-  if (gameErr || !game) {
-    return NextResponse.json({ error: 'Game not found' }, { status: 404 })
+  if (!game) {
+    await supabase
+      .from('herd_games')
+      .upsert(
+        { code: gameCode, owner_id: session.user.id, phase: 'round_setup' },
+        { onConflict: 'code' }
+      )
   }
 
   const body = await req.json().catch(() => ({} as any))

--- a/src/app/api/games/route.ts
+++ b/src/app/api/games/route.ts
@@ -28,6 +28,19 @@ export async function POST(_req: NextRequest) {
   if (lobbyError) {
     return NextResponse.json({ error: lobbyError.message }, { status: 500 })
   }
+  await supabase
+    .from('herd_games')
+    .upsert(
+      {
+        code: room.code,
+        owner_id: session.user.id,
+        phase: 'lobby',
+        total_rounds: 0,
+        active_round_index: 0,
+        lobby_locked: false,
+      },
+      { onConflict: 'code' }
+    )
 
   return NextResponse.json({ gameCode: room.code })
 }


### PR DESCRIPTION
## Summary
- Upsert a corresponding `herd_games` record when creating a game
- Round creation route now creates a `herd_games` entry if missing
- Moderator UI persists round configuration via `/config` before adding rounds

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68acabbdbbcc8327929dac51aad9e996