### PR TITLE
Fix round settings persistence and add unique round index

### DIFF
--- a/src/app/api/games/[code]/rounds/route.ts
+++ b/src/app/api/games/[code]/rounds/route.ts
@@ -85,6 +85,8 @@ export async function POST(req: Request, ctx: any) {
       idx: nextIndex,
       category: cat.id,
       count: count,
+      settings,
+      status: 'setup',
     })
     .select('id')
     .single()

--- a/src/app/api/games/[code]/rounds/start/route.ts
+++ b/src/app/api/games/[code]/rounds/start/route.ts
@@ -20,7 +20,7 @@ export async function POST(req: Request, ctx: any) {
   // načítaj konfiguráciu kola
   const { data: round, error: roundErr } = await s
     .from('herd_rounds')
-    .select('id, category, count')
+    .select('id, category, count, settings')
     .eq('game_code', code)
     .eq('idx', index)
     .single()
@@ -43,9 +43,11 @@ export async function POST(req: Request, ctx: any) {
 
   const questionIds = qs.map(q => q.id)
 
+  const newSettings = { ...(round.settings as any || {}), questions: questionIds }
+
   const { error: updErr } = await s
     .from('herd_rounds')
-    .update({ settings: { questions: questionIds }, status: 'running', q_index: 0 })
+    .update({ settings: newSettings, status: 'running', q_index: 0 })
     .eq('id', round.id)
 
   if (updErr) {

--- a/supabase/migrations/20250806200000_herd_games_owner_rounds.sql
+++ b/supabase/migrations/20250806200000_herd_games_owner_rounds.sql
@@ -28,7 +28,7 @@ alter table public.herd_rounds
   add column if not exists created_at timestamptz default now();
 
 create index if not exists herd_rounds_game_idx on public.herd_rounds (game_code);
-create index if not exists herd_rounds_game_idx_idx on public.herd_rounds (game_code, idx);
+create unique index if not exists herd_rounds_game_idx_idx on public.herd_rounds (game_code, idx);
 
 -- RLS policies for herd_games
 alter table public.herd_games enable row level security;


### PR DESCRIPTION
## Summary
- store round setup in herd_rounds and mark new rounds as setup
- preserve existing round settings when starting a round
- enforce unique (game_code, idx) constraint for rounds

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68acb6e4216c83278df2d06a63aca7ba