### PR TITLE
Refactor game API routes and clean up navigation

### DIFF
--- a/src/app/[lang]/apps/herd-vote/AdminWizard.tsx
+++ b/src/app/[lang]/apps/herd-vote/AdminWizard.tsx
@@ -136,7 +136,13 @@ export default function AdminWizard({ code: codeProp }: { code?: string }) {
         headers: { 'Content-Type': 'application/json' },
         body: body ? JSON.stringify(body) : undefined,
       })
-      if (!r.ok) throw new Error(await r.text())
+      if (!r.ok) {
+        let msg = await r.text()
+        try {
+          msg = JSON.parse(msg).error || msg
+        } catch {}
+        throw new Error(msg)
+      }
       await refresh()
     } catch (e:any) { setErr(e?.message ?? 'Chyba') }
 

--- a/src/app/[lang]/apps/herd-vote/page.tsx
+++ b/src/app/[lang]/apps/herd-vote/page.tsx
@@ -149,8 +149,18 @@ export default function HerdVoteAdminPage() {
       const catName = categories.find(c => c.id === selectedCat)?.name || selectedCat
       setRounds((prev) => [...prev, { id: j.roundId, category: catName }])
       if (totalRounds && newCount >= totalRounds) {
-        await authFetch(`/api/games/${gameCode}/start`, { method: 'POST' })
-        await authFetch(`/api/games/${gameCode}/rounds/start`, { method: 'POST' })
+        const startResp = await authFetch(`/api/games/${gameCode}/start`, { method: 'POST' })
+        const startJson = await startResp.json().catch(() => ({}))
+        if (!startResp.ok) {
+          alert(startJson.error || 'Nepodarilo sa spustiť hru')
+          return
+        }
+        const roundResp = await authFetch(`/api/games/${gameCode}/rounds/start`, { method: 'POST' })
+        const roundJson = await roundResp.json().catch(() => ({}))
+        if (!roundResp.ok || (!roundJson.ok && !roundJson.success)) {
+          alert(roundJson.error || 'Nepodarilo sa spustiť kolo')
+          return
+        }
         setGameStatus('running')
       }
     } else {
@@ -166,8 +176,8 @@ export default function HerdVoteAdminPage() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ roundId }),
     })
-    const j = await r.json()
-    if (!j.success) alert(j.error || 'Nepodarilo sa spustiť kolo')
+    const j = await r.json().catch(() => ({}))
+    if (!r.ok || !j.success) alert(j.error || 'Nepodarilo sa spustiť kolo')
   }
   const lockRound = async (roundId?: string) => {
     if (!gameCode) return

--- a/src/app/[lang]/apps/page.tsx
+++ b/src/app/[lang]/apps/page.tsx
@@ -30,9 +30,6 @@ export default async function AppsPage({ params }: P) {
           {apps.bannerTitle}
         </h1>
         <p className="text-lg text-muted-foreground">{apps.bannerSubtitle}</p>
-        <Button asChild size="lg">
-          <Link href="#games">{apps.bannerCTA}</Link>
-        </Button>
         <nav className="flex justify-center gap-4 pt-4 text-sm">
           {categories.map((cat) => (
             <Link key={cat.key} href={`#${cat.key}`} className="hover:underline">

--- a/src/app/admin/update-question/route.ts
+++ b/src/app/admin/update-question/route.ts
@@ -1,12 +1,12 @@
 ﻿
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabaseAdmin'
 import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
 import { cookies } from 'next/headers'
 
 const ADMIN_EMAILS = ['rezvalia@gmail.com', 'jozef.bubliak@gmail.com']
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   try {
     // Get the user's session with proper arguments
     const supabaseServer = createServerComponentClient({ cookies })

--- a/src/app/api/games/[code]/answers/route.ts
+++ b/src/app/api/games/[code]/answers/route.ts
@@ -1,12 +1,13 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
-export async function POST(req: Request) {
-  const url = new URL(req.url)
-  const segs = url.pathname.split('/')
-  const code = (segs[3] || '').toUpperCase()
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { code: string } }
+) {
+  const code = String(params.code).toUpperCase()
 
   const body = (await req.json().catch(() => ({}))) as {
     playerId?: string

--- a/src/app/api/games/[code]/config/route.ts
+++ b/src/app/api/games/[code]/config/route.ts
@@ -1,5 +1,5 @@
 // PATH: src/app/api/games/[code]/config/route.ts
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { supabaseServer } from '@/integrations/supabase/server'
 import { getSession } from '@/app/api/games/_session'
 
@@ -7,12 +7,12 @@ export const dynamic = 'force-dynamic'
 
 // Načítanie aktuálnej konfigurácie hry
 export async function GET(
-  _req: Request,
-  ctx: any
+  _req: NextRequest,
+  { params }: { params: { code: string } }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const code = String(ctx.params.code).toUpperCase()
+  const code = String(params.code).toUpperCase()
 
   const s = supabaseServer(session.access_token)
   const { data, error } = await s
@@ -40,12 +40,12 @@ export async function GET(
 
 // Uloženie / update konfigurácie hry
 export async function POST(
-  req: Request,
-  ctx: any
+  req: NextRequest,
+  { params }: { params: { code: string } }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const code = String(ctx.params.code).toUpperCase()
+  const code = String(params.code).toUpperCase()
 
   const body = await req.json().catch(() => ({} as any))
   const totalRounds =

--- a/src/app/api/games/[code]/end/route.ts
+++ b/src/app/api/games/[code]/end/route.ts
@@ -1,17 +1,17 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { getSession } from '@/app/api/games/_session'
 import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(
-  _req: Request,
-  ctx: any
+  _req: NextRequest,
+  { params }: { params: { code: string } }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const gameCode = String(ctx.params.code).toUpperCase()
+  const gameCode = String(params.code).toUpperCase()
 
   const supabase = supabaseServer(session.access_token)
 

--- a/src/app/api/games/[code]/leaderboard/route.ts
+++ b/src/app/api/games/[code]/leaderboard/route.ts
@@ -1,18 +1,18 @@
 // PATH: src/app/api/games/[code]/leaderboard/route.ts
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { supabaseServer } from '@/integrations/supabase/server'
 import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET(
-  _req: Request,
-  ctx: any
+  _req: NextRequest,
+  { params }: { params: { code: string } }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const code = String(ctx.params.code).toUpperCase()
+  const code = String(params.code).toUpperCase()
 
   const s = supabaseServer(session.access_token)
 

--- a/src/app/api/games/[code]/lock-lobby/route.ts
+++ b/src/app/api/games/[code]/lock-lobby/route.ts
@@ -1,27 +1,25 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { getSession } from '@/app/api/games/_session'
 import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(
-  _req: Request,
-  ctx: any
+  _req: NextRequest,
+  { params }: { params: { code: string } }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const code = String(ctx.params.code).toUpperCase()
+  const code = params.code.toUpperCase()
+  const s = supabaseServer(session.access_token)
 
-  const supabase = supabaseServer(session.access_token)
-  const { data, error } = await supabase.rpc('lock_lobby')
-  if (error || !data) {
-    return NextResponse.json(
-      { error: error?.message || 'Unable to lock lobby' },
-      { status: 400 },
-    )
-  }
+  const { error } = await s
+    .from('herd_games')
+    .update({ lobby_locked: true })
+    .eq('code', code)
+    .eq('owner_id', session.user.id)
 
-  return NextResponse.json({ success: true, status: data.status })
-
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 })
+  return NextResponse.json({ success: true, status: 'locked' })
 }

--- a/src/app/api/games/[code]/players/route.ts
+++ b/src/app/api/games/[code]/players/route.ts
@@ -1,5 +1,5 @@
 // PATH: src/app/api/games/[code]/players/route.ts
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { supabaseServer } from '@/integrations/supabase/server'
 import { randomUUID } from 'crypto'
 
@@ -14,10 +14,10 @@ type Participant = {
 
 // GET – vráti lobby (zoznam hráčov)
 export async function GET(
-  _req: Request,
-  ctx: any
+  _req: NextRequest,
+  { params }: { params: { code: string } }
 ) {
-  const gameCode = String(ctx.params.code).toUpperCase()
+  const gameCode = String(params.code).toUpperCase()
 
   const supabase = supabaseServer()
 
@@ -58,10 +58,10 @@ export async function GET(
 
 // POST – pridá hráča (kým je lobby otvorená)
 export async function POST(
-  req: Request,
-  ctx: any
+  req: NextRequest,
+  { params }: { params: { code: string } }
 ) {
-  const gameCode = String(ctx.params.code).toUpperCase()
+  const gameCode = String(params.code).toUpperCase()
 
   const body = (await req.json().catch(() => ({}))) as {
     name?: string

--- a/src/app/api/games/[code]/rounds/[roundId]/question/route.ts
+++ b/src/app/api/games/[code]/rounds/[roundId]/question/route.ts
@@ -1,5 +1,5 @@
 // PATH: src/app/api/games/[code]/rounds/[roundId]/question/route.ts
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
@@ -12,11 +12,11 @@ type FourAnswers = {
 }
 
 export async function GET(
-  req: Request,
-  ctx: any
+  req: NextRequest,
+  { params }: { params: { code: string; roundId: string } }
 ) {
-  const code = String(ctx.params.code).toUpperCase()
-  const roundId = String(ctx.params.roundId)
+  const code = String(params.code).toUpperCase()
+  const roundId = String(params.roundId)
 
   const url = new URL(req.url)
   const qIndexParam = url.searchParams.get('qIndex')

--- a/src/app/api/games/[code]/rounds/config/route.ts
+++ b/src/app/api/games/[code]/rounds/config/route.ts
@@ -1,17 +1,17 @@
 // PATH: src/app/api/games/[code]/rounds/config/route.ts
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { supabaseServer } from '@/integrations/supabase/server'
 import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(
-  req: Request,
-  ctx: any
+  req: NextRequest,
+  { params }: { params: { code: string } }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const code = String(ctx.params.code).toUpperCase()
+  const code = String(params.code).toUpperCase()
 
   // bezpečné načítanie body
   const body = await req.json().catch(() => ({} as any))

--- a/src/app/api/games/[code]/rounds/lock/route.ts
+++ b/src/app/api/games/[code]/rounds/lock/route.ts
@@ -1,5 +1,5 @@
 // PATH: src/app/api/games/[code]/rounds/lock/route.ts
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { RealtimeServer } from '@/lib/realtime/server'
 import { channelFor } from '@/lib/realtime/types'
 import { supabaseServer } from '@/integrations/supabase/server'
@@ -8,13 +8,13 @@ import { getSession } from '@/app/api/games/_session'
 export const dynamic = 'force-dynamic'
 
 export async function POST(
-  req: Request,
-  ctx: any
+  req: NextRequest,
+  { params }: { params: { code: string } }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const code = String(ctx.params.code).toUpperCase()
+  const code = String(params.code).toUpperCase()
   const body = await req.json().catch(() => ({})) as { roundId?: string }
 
   const s = supabaseServer(session.access_token)

--- a/src/app/api/games/[code]/rounds/next/route.ts
+++ b/src/app/api/games/[code]/rounds/next/route.ts
@@ -1,5 +1,5 @@
 // PATH: src/app/api/games/[code]/rounds/next/route.ts
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { RealtimeServer } from '@/lib/realtime/server'
 import { channelFor } from '@/lib/realtime/types'
 import { supabaseServer } from '@/integrations/supabase/server'
@@ -8,13 +8,13 @@ import { getSession } from '@/app/api/games/_session'
 export const dynamic = 'force-dynamic'
 
 export async function POST(
-  req: Request,
-  ctx: any
+  req: NextRequest,
+  { params }: { params: { code: string } }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const code = String(ctx.params.code).toUpperCase()
+  const code = String(params.code).toUpperCase()
 
   const body = await req.json().catch(() => ({})) as { roundId?: string }
   const s = supabaseServer(session.access_token)

--- a/src/app/api/games/[code]/rounds/results/route.ts
+++ b/src/app/api/games/[code]/rounds/results/route.ts
@@ -1,5 +1,5 @@
 // PATH: src/app/api/games/[code]/rounds/results/route.ts
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { RealtimeServer } from '@/lib/realtime/server'
 import { channelFor } from '@/lib/realtime/types'
 import { calculateRoundScores } from '@/lib/herdvote/scoring'
@@ -9,12 +9,12 @@ import { getSession } from '@/app/api/games/_session'
 export const dynamic = 'force-dynamic'
 
 export async function POST(
-  req: Request,
-  ctx: any
+  req: NextRequest,
+  { params }: { params: { code: string } }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const code = String(ctx.params.code).toUpperCase()
+  const code = String(params.code).toUpperCase()
 
   const body = await req.json().catch(() => ({})) as { roundId?: string }
 

--- a/src/app/api/games/[code]/rounds/route.ts
+++ b/src/app/api/games/[code]/rounds/route.ts
@@ -1,5 +1,5 @@
 // PATH: src/app/api/games/[code]/rounds/route.ts
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import type { RoundSettings } from '@/lib/herdvote/store'
 import { getSession } from '@/app/api/games/_session'
 import { supabaseServer } from '@/integrations/supabase/server'
@@ -16,12 +16,12 @@ export const dynamic = 'force-dynamic'
  * }
  */
 export async function POST(
-  req: Request,
-  ctx: any
+  req: NextRequest,
+  { params }: { params: { code: string } }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const gameCode = String(ctx.params.code).toUpperCase()
+  const gameCode = String(params.code).toUpperCase()
 
   const supabase = supabaseServer(session.access_token)
 

--- a/src/app/api/games/[code]/rounds/start/route.ts
+++ b/src/app/api/games/[code]/rounds/start/route.ts
@@ -1,17 +1,17 @@
 // PATH: src/app/api/games/[code]/rounds/start/route.ts
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { supabaseServer } from '@/integrations/supabase/server'
 import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(
-  req: Request,
-  ctx: any
+  req: NextRequest,
+  { params }: { params: { code: string } }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const code = String(ctx.params.code).toUpperCase()
+  const code = String(params.code).toUpperCase()
 
   const body = await req.json().catch(() => ({} as any))
   const index = typeof body?.index === 'number' ? body.index : 0

--- a/src/app/api/games/[code]/rounds/timer/start/route.ts
+++ b/src/app/api/games/[code]/rounds/timer/start/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { RealtimeServer } from '@/lib/realtime/server'
 import { channelFor } from '@/lib/realtime/types'
 import { supabaseServer } from '@/integrations/supabase/server'
@@ -7,13 +7,13 @@ import { getSession } from '@/app/api/games/_session'
 export const dynamic = 'force-dynamic'
 
 export async function POST(
-  req: Request,
-  ctx: any
+  req: NextRequest,
+  { params }: { params: { code: string } }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const code = String(ctx.params.code).toUpperCase()
+  const code = String(params.code).toUpperCase()
 
   const body = await req.json().catch(() => ({})) as {
     seconds?: number

--- a/src/app/api/games/[code]/route.ts
+++ b/src/app/api/games/[code]/route.ts
@@ -1,14 +1,14 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { getSession } from '@/app/api/games/_session'
 import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET(
-  _req: Request,
-  ctx: any
+  _req: NextRequest,
+  { params }: { params: { code: string } }
 ) {
-  const code = String(ctx.params.code).toUpperCase()
+  const code = String(params.code).toUpperCase()
 
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })

--- a/src/app/api/games/[code]/start/route.ts
+++ b/src/app/api/games/[code]/start/route.ts
@@ -1,26 +1,25 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { getSession } from '@/app/api/games/_session'
 import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(
-  _req: Request,
-  ctx: any
+  _req: NextRequest,
+  { params }: { params: { code: string } }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const code = String(ctx.params.code).toUpperCase()
+  const code = params.code.toUpperCase()
+  const s = supabaseServer(session.access_token)
 
-  const supabase = supabaseServer(session.access_token)
-
-  const { error: gErr } = await supabase
+  const { error } = await s
     .from('herd_games')
-    .update({ phase: 'setup' })
+    .update({ phase: 'playing' })
     .eq('code', code)
+    .eq('owner_id', session.user.id)
 
-  if (gErr) return NextResponse.json({ error: gErr.message }, { status: 400 })
-
-  return NextResponse.json({ success: true, status: 'setup' })
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 })
+  return NextResponse.json({ success: true, status: 'playing' })
 }

--- a/src/app/api/questions/[id]/route.ts
+++ b/src/app/api/questions/[id]/route.ts
@@ -1,15 +1,15 @@
 // src/app/api/questions/[id]/route.ts
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabaseAdmin' // server-side client (service role)
 
 export const dynamic = 'force-dynamic'
 
 export async function GET(
-  _req: Request,
-  ctx: any
+  _req: NextRequest,
+  { params }: { params: { id: string } }
 ) {
   try {
-    const questionId = parseInt(String(ctx.params.id), 10)
+    const questionId = parseInt(String(params.id), 10)
 
     if (!Number.isFinite(questionId) || questionId <= 0) {
       return NextResponse.json({ error: 'Invalid question ID' }, { status: 400 })

--- a/src/components/LegacyApp.tsx
+++ b/src/components/LegacyApp.tsx
@@ -62,29 +62,34 @@ const router = useRouter()
   const loadFavorites = async () => {
     if (!group || !user) return
 
-    const { data } = await supabase
-      .from('user_favorites')
-      .select(`
+    if (false) {
+      const { data } = await supabase
+        .from('user_favorites')
+        .select(`
         question_id,
         questions (
           id, text, partneri, kamarati, rodina, rodic_dieta
         )
       `)
-      .eq('user_id', user.id)
+        .eq('user_id', user.id)
 
-    const filteredFavorites = data?.filter(
-      (item: any) =>
-        item.questions &&
-        Array.isArray(item.questions) &&
-        item.questions.length > 0 &&
-        item.questions[0][group]
-    ) || []
+      const filteredFavorites = data?.filter(
+        (item: any) =>
+          item.questions &&
+          Array.isArray(item.questions) &&
+          item.questions.length > 0 &&
+          item.questions[0][group]
+      ) || []
 
-    setFavoritesList(filteredFavorites)
-    if (filteredFavorites.length > 0 && filteredFavorites[0]?.questions?.[0]) {
-      setCurrentQuestion(filteredFavorites[0].questions[0])
-      setCurrentFavoriteIndex(0)
+      setFavoritesList(filteredFavorites)
+      if (filteredFavorites.length > 0 && filteredFavorites[0]?.questions?.[0]) {
+        setCurrentQuestion(filteredFavorites[0].questions[0])
+        setCurrentFavoriteIndex(0)
+      } else {
+        setCurrentQuestion(null)
+      }
     } else {
+      setFavoritesList([])
       setCurrentQuestion(null)
     }
   }

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -19,9 +19,7 @@ export default function SiteHeader({ lang: propLang }: { lang?: string }) {
     { href: `/${l}`,                label: t("nav.home","Domov") },
     { href: `/${l}/produkty`,       label: t("nav.products","Produkty") },
     { href: `/${l}/kompas`,         label: t("nav.tools","Komunikačný kompas") },
-    { href: `/${l}/blog`,           label: t("nav.blog","Blog") },
-    { href: `/${l}/downloads`,      label: t("nav.downloads","Downloady") },
-    { href: `/${l}/apps`,           label: t("nav.apps","Konverzačné hry") },
+    { href: `/${l}/apps#games`,     label: t("nav.apps","Konverzačné hry") },
   ]
 
   return (

--- a/src/hooks/createUseAuth.tsx
+++ b/src/hooks/createUseAuth.tsx
@@ -25,27 +25,31 @@ export function createUseAuth(client: SupabaseClient, cookieName?: string) {
 
         if (session?.user) {
           setTimeout(async () => {
-            const { data: profileData } = await client
-              .from('user_profiles')
-              .select('*')
-              .eq('id', session.user.id)
-              .single()
-
-            if (!profileData) {
-              const { data: inserted } = await client
+            if (false) {
+              const { data: profileData } = await client
                 .from('user_profiles')
-                .insert({
-                  id: session.user.id,
-                  email: session.user.email ?? '',
-                  paid_access: false,
-                  daily_questions_date: null,
-                  daily_questions_used: 0,
-                })
                 .select('*')
+                .eq('id', session.user.id)
                 .single()
-              setProfile(inserted)
+
+              if (!profileData) {
+                const { data: inserted } = await client
+                  .from('user_profiles')
+                  .insert({
+                    id: session.user.id,
+                    email: session.user.email ?? '',
+                    paid_access: false,
+                    daily_questions_date: null,
+                    daily_questions_used: 0,
+                  })
+                  .select('*')
+                  .single()
+                setProfile(inserted)
+              } else {
+                setProfile(profileData)
+              }
             } else {
-              setProfile(profileData)
+              setProfile(null)
             }
           }, 0)
         } else {

--- a/src/hooks/useQuestions.tsx
+++ b/src/hooks/useQuestions.tsx
@@ -37,28 +37,36 @@ export function useQuestions() {
   const fetchUserData = async () => {
     if (!user) return
 
-    // Fetch viewed questions
-    const { data: historyData } = await supabase
-      .from('user_question_history')
-      .select('question_id')
-      .eq('user_id', user.id)
+    // Fetch viewed questions (disabled until user_question_history exists)
+    if (false) {
+      const { data: historyData } = await supabase
+        .from('user_question_history')
+        .select('question_id')
+        .eq('user_id', user.id)
 
-    if (historyData) {
-      setViewedQuestions(historyData.map(h => h.question_id))
+      if (historyData) {
+        setViewedQuestions(historyData.map(h => h.question_id))
+      }
+    } else {
+      setViewedQuestions([])
     }
 
-    // Fetch favorites
-    const { data: favData } = await supabase
-      .from('user_favorites')
-      .select('question_id')
-      .eq('user_id', user.id)
+    // Fetch favorites (disabled until user_favorites exists)
+    if (false) {
+      const { data: favData } = await supabase
+        .from('user_favorites')
+        .select('question_id')
+        .eq('user_id', user.id)
 
-    if (favData) {
-      setFavorites(favData.map(f => f.question_id))
+      if (favData) {
+        setFavorites(favData.map(f => f.question_id))
+      }
+    } else {
+      setFavorites([])
     }
 
     // Check daily usage
-    if (profile) {
+    if (false && profile) {
       const today = new Date().toISOString().split('T')[0]
       if (profile.daily_questions_date === today) {
         setDailyCount(profile.daily_questions_used)
@@ -73,6 +81,8 @@ export function useQuestions() {
           })
           .eq('id', user.id)
       }
+    } else {
+      setDailyCount(0)
     }
   }
 
@@ -132,13 +142,15 @@ export function useQuestions() {
       .single()
 
     if (question && user) {
-      // Mark as viewed
-      await supabase
-        .from('user_question_history')
-        .upsert({
-          user_id: user.id,
-          question_id: question.id
-        })
+      // Mark as viewed (disabled until user_question_history exists)
+      if (false) {
+        await supabase
+          .from('user_question_history')
+          .upsert({
+            user_id: user.id,
+            question_id: question.id
+          })
+      }
 
       setViewedQuestions(prev => [...prev, question.id])
 
@@ -146,13 +158,15 @@ export function useQuestions() {
       if (!isPaid) {
         const newCount = dailyCount + 1
         setDailyCount(newCount)
-        
-        await supabase
-          .from('user_profiles')
-          .update({
-            daily_questions_used: newCount
-          })
-          .eq('id', user.id)
+
+        if (false) {
+          await supabase
+            .from('user_profiles')
+            .update({
+              daily_questions_used: newCount
+            })
+            .eq('id', user.id)
+        }
       }
     }
 
@@ -165,21 +179,23 @@ export function useQuestions() {
     const isFavorite = favorites.includes(questionId)
     
     if (isFavorite) {
-      await supabase
-        .from('user_favorites')
-        .delete()
-        .eq('user_id', user.id)
-        .eq('question_id', questionId)
-      
+      if (false) {
+        await supabase
+          .from('user_favorites')
+          .delete()
+          .eq('user_id', user.id)
+          .eq('question_id', questionId)
+      }
       setFavorites(prev => prev.filter(id => id !== questionId))
     } else {
-      await supabase
-        .from('user_favorites')
-        .insert({
-          user_id: user.id,
-          question_id: questionId
-        })
-      
+      if (false) {
+        await supabase
+          .from('user_favorites')
+          .insert({
+            user_id: user.id,
+            question_id: questionId
+          })
+      }
       setFavorites(prev => [...prev, questionId])
     }
   }


### PR DESCRIPTION
## Summary
- use typed NextRequest handlers across game API routes and fix start/lock lobby actions
- remove broken navigation links and self-referential apps button
- disable calls to missing user_* tables in auth and question hooks

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae01172b9483278a80dd679d0f180c