### PR TITLE
fix herd vote API contract and build errors

### DIFF
--- a/src/app/[lang]/apps/herd-vote/AdminWizard.tsx
+++ b/src/app/[lang]/apps/herd-vote/AdminWizard.tsx
@@ -58,7 +58,7 @@ export default function AdminWizard({ code: codeProp }: { code?: string }) {
   const [roundCfg, setRoundCfg] = useState<RoundCfg>({ topic: '', questions: 5 })
   const [players, setPlayers] = useState<{id:string; name:string}[]>([])
   const [categories, setCategories] = useState<Category[]>([])
-  const timerRef = useRef<NodeJS.Timeout | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     (async () => {

--- a/src/app/[lang]/apps/herd-vote/page.tsx
+++ b/src/app/[lang]/apps/herd-vote/page.tsx
@@ -138,27 +138,34 @@ export default function HerdVoteAdminPage() {
         ? { mode, correct, incorrect, none }
         : { mode, tiers: [tier1, tier2, tier3], incorrect: pIncorrect, none: pNone }
 
-    const r = await authFetch(`/api/games/${gameCode}/rounds`, {
+    // uloženie konfigurácie konkrétneho kola (index = poradie)
+    const r = await authFetch(`/api/games/${gameCode}/rounds/config`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ categoryId: selectedCat, count, settings: { timeLimit, scoring } }),
+      body: JSON.stringify({
+        index: rounds.length,
+        categoryId: selectedCat,
+        questions: count,
+        prepSeconds: timeLimit,
+        questionSeconds: timeLimit,
+        scoringMode: scoring.mode === 'classic' ? 'simple' : 'weighted',
+      }),
     })
     const j = await r.json()
     if (j.roundId) {
       const newCount = rounds.length + 1
       const catName = categories.find(c => c.id === selectedCat)?.name || selectedCat
-      setRounds((prev) => [...prev, { id: j.roundId, category: catName }])
+      setRounds(prev => [...prev, { id: j.roundId, category: catName }])
       if (totalRounds && newCount >= totalRounds) {
-        const startResp = await authFetch(`/api/games/${gameCode}/start`, { method: 'POST' })
+        // štart prvej otázky prvého kola
+        const startResp = await authFetch(`/api/games/${gameCode}/rounds/start`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ index: 0 }),
+        })
         const startJson = await startResp.json().catch(() => ({}))
         if (!startResp.ok) {
           alert(startJson.error || 'Nepodarilo sa spustiť hru')
-          return
-        }
-        const roundResp = await authFetch(`/api/games/${gameCode}/rounds/start`, { method: 'POST' })
-        const roundJson = await roundResp.json().catch(() => ({}))
-        if (!roundResp.ok || (!roundJson.ok && !roundJson.success)) {
-          alert(roundJson.error || 'Nepodarilo sa spustiť kolo')
           return
         }
         setGameStatus('running')

--- a/src/app/api/games/[code]/answers/route.ts
+++ b/src/app/api/games/[code]/answers/route.ts
@@ -3,9 +3,10 @@ import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
-type Ctx = { params: { code: string } }
-
-export async function POST(req: NextRequest, { params }: Ctx) {
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { code: string } }
+) {
   const code = String(params.code).toUpperCase()
 
   const body = (await req.json().catch(() => ({}))) as {

--- a/src/app/api/games/[code]/config/route.ts
+++ b/src/app/api/games/[code]/config/route.ts
@@ -6,9 +6,11 @@ import { getSession } from '@/app/api/games/_session'
 export const dynamic = 'force-dynamic'
 
 // Načítanie aktuálnej konfigurácie hry
-type Ctx = { params: { code: string } }
 
-export async function GET(_req: NextRequest, { params }: Ctx) {
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { code: string } }
+) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const code = String(params.code).toUpperCase()
@@ -38,7 +40,10 @@ export async function GET(_req: NextRequest, { params }: Ctx) {
 }
 
 // Uloženie / update konfigurácie hry
-export async function POST(req: NextRequest, { params }: Ctx) {
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { code: string } }
+) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const code = String(params.code).toUpperCase()

--- a/src/app/api/games/[code]/end/route.ts
+++ b/src/app/api/games/[code]/end/route.ts
@@ -4,37 +4,28 @@ import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
-type Ctx = { params: { code: string } }
-
-export async function POST(_req: NextRequest, { params }: Ctx) {
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: { code: string } }
+) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const gameCode = String(params.code).toUpperCase()
+  const code = String(params.code).toUpperCase()
+  const s = supabaseServer(session.access_token)
 
-  const supabase = supabaseServer(session.access_token)
-
-  const { data: room } = await supabase
-    .from('rooms')
-    .select('id')
-    .eq('code', gameCode)
+  const { data: game } = await s
+    .from('herd_games')
+    .select('code, owner_id')
+    .eq('code', code)
     .eq('owner_id', session.user.id)
     .single()
 
-  if (!room) return NextResponse.json({ error: 'Game not found' }, { status: 404 })
+  if (!game) return NextResponse.json({ error: 'Game not found' }, { status: 404 })
 
-  const { data: gs } = await supabase
-    .from('game_sessions')
-    .select('id')
-    .eq('room_id', room.id)
-    .in('status', ['lobby', 'setup', 'running'])
-    .order('created_at', { ascending: false })
-    .limit(1)
-    .maybeSingle()
-
-  if (gs) {
-    await supabase.from('game_sessions').update({ status: 'ended' }).eq('id', gs.id)
-  }
+  await s.from('herd_rounds').update({ status: 'finished' }).eq('game_code', code)
+  await s.from('herd_games').update({ phase: 'final' }).eq('code', code)
 
   return NextResponse.json({ success: true })
 }
+

--- a/src/app/api/games/[code]/leaderboard/route.ts
+++ b/src/app/api/games/[code]/leaderboard/route.ts
@@ -5,9 +5,10 @@ import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-type Ctx = { params: { code: string } }
-
-export async function GET(_req: NextRequest, { params }: Ctx) {
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { code: string } }
+) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 

--- a/src/app/api/games/[code]/lock-lobby/route.ts
+++ b/src/app/api/games/[code]/lock-lobby/route.ts
@@ -4,9 +4,10 @@ import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
-type Ctx = { params: { code: string } }
-
-export async function POST(_req: NextRequest, { params }: Ctx) {
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: { code: string } }
+) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 

--- a/src/app/api/games/[code]/players/route.ts
+++ b/src/app/api/games/[code]/players/route.ts
@@ -13,9 +13,10 @@ type Participant = {
 }
 
 // GET – vráti lobby (zoznam hráčov)
-type Ctx = { params: { code: string } }
-
-export async function GET(_req: NextRequest, { params }: Ctx) {
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { code: string } }
+) {
   const gameCode = String(params.code).toUpperCase()
 
   const supabase = supabaseServer()
@@ -56,7 +57,10 @@ export async function GET(_req: NextRequest, { params }: Ctx) {
 }
 
 // POST – pridá hráča (kým je lobby otvorená)
-export async function POST(req: NextRequest, { params }: Ctx) {
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { code: string } }
+) {
   const gameCode = String(params.code).toUpperCase()
 
   const body = (await req.json().catch(() => ({}))) as {

--- a/src/app/api/games/[code]/rounds/[roundId]/question/route.ts
+++ b/src/app/api/games/[code]/rounds/[roundId]/question/route.ts
@@ -11,9 +11,10 @@ type FourAnswers = {
   answer_d?: string
 }
 
-type Ctx = { params: { code: string; roundId: string } }
-
-export async function GET(req: NextRequest, { params }: Ctx) {
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { code: string; roundId: string } }
+) {
   const code = String(params.code).toUpperCase()
   const roundId = String(params.roundId)
 

--- a/src/app/api/games/[code]/rounds/config/route.ts
+++ b/src/app/api/games/[code]/rounds/config/route.ts
@@ -5,9 +5,10 @@ import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-type Ctx = { params: { code: string } }
-
-export async function POST(req: NextRequest, { params }: Ctx) {
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { code: string } }
+) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const code = String(params.code).toUpperCase()
@@ -19,7 +20,7 @@ export async function POST(req: NextRequest, { params }: Ctx) {
   const s = supabaseServer(session.access_token) as any // "as any" obíde TS typy generované zo Supabase
 
   // uloženie/aktualizácia kola (idempotentne podľa game_code + idx)
-  const { error } = await s
+  const { data: saved, error } = await s
     .from('herd_rounds')
     .upsert(
       {
@@ -34,8 +35,12 @@ export async function POST(req: NextRequest, { params }: Ctx) {
       },
       { onConflict: 'game_code,idx' }
     )
+    .select('id')
+    .single()
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 400 })
+  if (error || !saved) {
+    return NextResponse.json({ error: error?.message || 'Unable to save round' }, { status: 400 })
+  }
 
   // udržujeme phase v herd_games
   await s.from('herd_games').update({ phase: 'round_setup' }).eq('code', code)
@@ -55,5 +60,5 @@ export async function POST(req: NextRequest, { params }: Ctx) {
     // nič – len nech to nepadne, keď typy/kolónky chýbajú
   }
 
-  return NextResponse.json({ ok: true, phase: 'round_setup', savedIndex: index })
+  return NextResponse.json({ ok: true, roundId: saved.id, phase: 'round_setup', savedIndex: index })
 }

--- a/src/app/api/games/[code]/rounds/lock/route.ts
+++ b/src/app/api/games/[code]/rounds/lock/route.ts
@@ -7,9 +7,10 @@ import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-type Ctx = { params: { code: string } }
-
-export async function POST(req: NextRequest, { params }: Ctx) {
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { code: string } }
+) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 

--- a/src/app/api/games/[code]/rounds/next/route.ts
+++ b/src/app/api/games/[code]/rounds/next/route.ts
@@ -7,9 +7,10 @@ import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-type Ctx = { params: { code: string } }
-
-export async function POST(req: NextRequest, { params }: Ctx) {
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { code: string } }
+) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
@@ -75,7 +76,7 @@ export async function POST(req: NextRequest, { params }: Ctx) {
 
   await s
     .from('herd_rounds')
-    .update({ q_index: nextQIndex, status: 'running' })
+    .update({ q_index: nextQIndex, status: 'shown' })
     .eq('id', round.id)
 
   await RealtimeServer.publish(channelFor(code), {

--- a/src/app/api/games/[code]/rounds/results/route.ts
+++ b/src/app/api/games/[code]/rounds/results/route.ts
@@ -8,9 +8,10 @@ import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-type Ctx = { params: { code: string } }
-
-export async function POST(req: NextRequest, { params }: Ctx) {
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { code: string } }
+) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const code = String(params.code).toUpperCase()
@@ -76,7 +77,23 @@ export async function POST(req: NextRequest, { params }: Ctx) {
     ts: new Date(a.answered_at as any).getTime(),
   }))
 
-  const scoring = { mode: 'classic', correct: 1, incorrect: 0, none: 0 } as const
+  // načítaj scoring z kola (preferuj settings, inak fallback)
+  const mode = (round.settings as any)?.scoring?.mode
+    ?? (round as any).scoring_mode
+    ?? 'classic'
+
+  let scoring: any
+  if (mode === 'podium') {
+    const tiers = (round.settings as any)?.scoring?.tiers ?? [10,5,3]
+    const incorrect = (round.settings as any)?.scoring?.incorrect ?? -3
+    const none = (round.settings as any)?.scoring?.none ?? 0
+    scoring = { mode: 'podium', tiers, incorrect, none } as const
+  } else {
+    const correct = (round.settings as any)?.scoring?.correct ?? 5
+    const incorrect = (round.settings as any)?.scoring?.incorrect ?? -3
+    const none = (round.settings as any)?.scoring?.none ?? 0
+    scoring = { mode: 'classic', correct, incorrect, none } as const
+  }
 
   const questionScores = calculateRoundScores(
     playerAnswers,

--- a/src/app/api/games/[code]/rounds/route.ts
+++ b/src/app/api/games/[code]/rounds/route.ts
@@ -15,9 +15,11 @@ export const dynamic = 'force-dynamic'
  *   "settings": { timeLimit: 30, scoring: {...} } as RoundSettings
  * }
  */
-type Ctx = { params: { code: string } }
 
-export async function POST(req: NextRequest, { params }: Ctx) {
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { code: string } }
+) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const gameCode = String(params.code).toUpperCase()

--- a/src/app/api/games/[code]/rounds/start/route.ts
+++ b/src/app/api/games/[code]/rounds/start/route.ts
@@ -5,9 +5,10 @@ import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-type Ctx = { params: { code: string } }
-
-export async function POST(req: NextRequest, { params }: Ctx) {
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { code: string } }
+) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const code = String(params.code).toUpperCase()
@@ -47,7 +48,7 @@ export async function POST(req: NextRequest, { params }: Ctx) {
 
   const { error: updErr } = await s
     .from('herd_rounds')
-    .update({ settings: newSettings, status: 'running', q_index: 0 })
+    .update({ settings: newSettings, status: 'shown', q_index: 0 })
     .eq('id', round.id)
 
   if (updErr) {

--- a/src/app/api/games/[code]/rounds/timer/start/route.ts
+++ b/src/app/api/games/[code]/rounds/timer/start/route.ts
@@ -6,9 +6,10 @@ import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
-type Ctx = { params: { code: string } }
-
-export async function POST(req: NextRequest, { params }: Ctx) {
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { code: string } }
+) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 

--- a/src/app/api/games/[code]/route.ts
+++ b/src/app/api/games/[code]/route.ts
@@ -4,9 +4,10 @@ import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
-type Ctx = { params: { code: string } }
-
-export async function GET(_req: NextRequest, { params }: Ctx) {
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { code: string } }
+) {
   const code = String(params.code).toUpperCase()
 
   const session = await getSession()

--- a/src/app/api/games/[code]/start/route.ts
+++ b/src/app/api/games/[code]/start/route.ts
@@ -4,9 +4,10 @@ import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
-type Ctx = { params: { code: string } }
-
-export async function POST(_req: NextRequest, { params }: Ctx) {
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: { code: string } }
+) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 

--- a/src/app/api/games/active/route.ts
+++ b/src/app/api/games/active/route.ts
@@ -4,38 +4,22 @@ import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
-const INACTIVITY_MS = 15 * 60 * 1000
-
 export async function GET(_req: NextRequest) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const supabase = supabaseServer(session.access_token)
+  const s = supabaseServer(session.access_token)
 
-  const { data: room } = await supabase
-    .from('rooms')
-    .select('id, code')
+  const { data: g } = await s
+    .from('herd_games')
+    .select('code, phase, updated_at')
     .eq('owner_id', session.user.id)
-    .single()
-
-  if (!room) return NextResponse.json({}, { status: 204 })
-
-  const { data: gs } = await supabase
-    .from('game_sessions')
-    .select('id, status, updated_at, created_at')
-    .eq('room_id', room.id)
-    .in('status', ['lobby', 'setup', 'running'])
-    .order('created_at', { ascending: false })
+    .order('updated_at', { ascending: false })
     .limit(1)
     .maybeSingle()
 
-  if (!gs) return NextResponse.json({}, { status: 204 })
+  if (!g) return NextResponse.json({}, { status: 204 })
 
-  const last = new Date(gs.updated_at ?? gs.created_at ?? Date.now())
-  if (Date.now() - last.getTime() > INACTIVITY_MS) {
-    await supabase.from('game_sessions').update({ status: 'ended' }).eq('id', gs.id)
-    return NextResponse.json({}, { status: 204 })
-  }
-
-  return NextResponse.json({ code: room.code, status: gs.status })
+  return NextResponse.json({ code: g.code, status: g.phase || 'lobby' })
 }
+


### PR DESCRIPTION
## Summary
- align herd-vote admin page with /rounds/config and /rounds/start endpoints
- unify round phases and timer logic (shown → running) and load scoring from config
- rewrite game end/active handlers to use herd_* tables and clean up route type signatures

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae134eec4c832787ece356371a1c64