### PR TITLE
fix: update Next.js route params for 15

### DIFF
--- a/src/app/api/games/[code]/answers/route.ts
+++ b/src/app/api/games/[code]/answers/route.ts
@@ -1,13 +1,14 @@
-import { NextResponse, type NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
 import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(
-  req: NextRequest,
-  { params }: { params: { code: string } }
+  req: Request,
+  ctx: { params: Promise<{ code: string }> }
 ) {
-  const code = String(params.code).toUpperCase()
+  const { code } = await ctx.params
+  const gameCode = String(code).toUpperCase()
 
   const body = (await req.json().catch(() => ({}))) as {
     playerId?: string
@@ -17,7 +18,7 @@ export async function POST(
   }
 
   const { playerId, roundId, qIndex, answer } = body
-  if (!code || !playerId || !roundId || typeof qIndex !== 'number') {
+  if (!gameCode || !playerId || !roundId || typeof qIndex !== 'number') {
     return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
   }
 
@@ -26,7 +27,7 @@ export async function POST(
   const { data: game, error: gErr } = await s
     .from('herd_games')
     .select('code')
-    .eq('code', code)
+    .eq('code', gameCode)
     .maybeSingle()
 
   if (gErr) return NextResponse.json({ error: gErr.message }, { status: 500 })
@@ -36,7 +37,7 @@ export async function POST(
     .from('herd_answers')
     .upsert(
       {
-        game_code: code,
+        game_code: gameCode,
         player_id: playerId,
         round_id: roundId,
         q_index: qIndex,

--- a/src/app/api/games/[code]/config/route.ts
+++ b/src/app/api/games/[code]/config/route.ts
@@ -1,5 +1,5 @@
 // PATH: src/app/api/games/[code]/config/route.ts
-import { NextResponse, type NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
 import { supabaseServer } from '@/integrations/supabase/server'
 import { getSession } from '@/app/api/games/_session'
 
@@ -8,18 +8,19 @@ export const dynamic = 'force-dynamic'
 // Načítanie aktuálnej konfigurácie hry
 
 export async function GET(
-  _req: NextRequest,
-  { params }: { params: { code: string } }
+  _req: Request,
+  ctx: { params: Promise<{ code: string }> }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const code = String(params.code).toUpperCase()
+  const { code } = await ctx.params
+  const gameCode = String(code).toUpperCase()
 
   const s = supabaseServer(session.access_token)
   const { data, error } = await s
     .from('herd_games')
     .select('code,total_rounds,prep_seconds,question_seconds,scoring_mode')
-    .eq('code', code)
+    .eq('code', gameCode)
     .eq('owner_id', session.user.id)
     .single()
 
@@ -41,12 +42,13 @@ export async function GET(
 
 // Uloženie / update konfigurácie hry
 export async function POST(
-  req: NextRequest,
-  { params }: { params: { code: string } }
+  req: Request,
+  ctx: { params: Promise<{ code: string }> }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const code = String(params.code).toUpperCase()
+  const { code } = await ctx.params
+  const gameCode = String(code).toUpperCase()
 
   const body = await req.json().catch(() => ({} as any))
   const totalRounds =
@@ -71,7 +73,7 @@ export async function POST(
   const s = supabaseServer(session.access_token)
   const { error } = await s
     .from('herd_games')
-    .upsert({ code, ...updates }, { onConflict: 'code' })
+    .upsert({ code: gameCode, ...updates }, { onConflict: 'code' })
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 400 })

--- a/src/app/api/games/[code]/end/route.ts
+++ b/src/app/api/games/[code]/end/route.ts
@@ -1,30 +1,31 @@
-import { NextResponse, type NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
 import { getSession } from '@/app/api/games/_session'
 import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(
-  _req: NextRequest,
-  { params }: { params: { code: string } }
+  _req: Request,
+  ctx: { params: Promise<{ code: string }> }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const code = String(params.code).toUpperCase()
+  const { code } = await ctx.params
+  const gameCode = String(code).toUpperCase()
   const s = supabaseServer(session.access_token)
 
   const { data: game } = await s
     .from('herd_games')
     .select('code, owner_id')
-    .eq('code', code)
+    .eq('code', gameCode)
     .eq('owner_id', session.user.id)
     .single()
 
   if (!game) return NextResponse.json({ error: 'Game not found' }, { status: 404 })
 
-  await s.from('herd_rounds').update({ status: 'finished' }).eq('game_code', code)
-  await s.from('herd_games').update({ phase: 'final' }).eq('code', code)
+  await s.from('herd_rounds').update({ status: 'finished' }).eq('game_code', gameCode)
+  await s.from('herd_games').update({ phase: 'final' }).eq('code', gameCode)
 
   return NextResponse.json({ success: true })
 }

--- a/src/app/api/games/[code]/leaderboard/route.ts
+++ b/src/app/api/games/[code]/leaderboard/route.ts
@@ -1,25 +1,26 @@
 // PATH: src/app/api/games/[code]/leaderboard/route.ts
-import { NextResponse, type NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
 import { supabaseServer } from '@/integrations/supabase/server'
 import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET(
-  _req: NextRequest,
-  { params }: { params: { code: string } }
+  _req: Request,
+  ctx: { params: Promise<{ code: string }> }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const code = String(params.code).toUpperCase()
+  const { code } = await ctx.params
+  const gameCode = String(code).toUpperCase()
 
   const s = supabaseServer(session.access_token)
 
   const { data: players } = await s
     .from('herd_players')
     .select('name, score')
-    .eq('game_code', code)
+    .eq('game_code', gameCode)
     .order('score', { ascending: false })
 
   return NextResponse.json(players || [])

--- a/src/app/api/games/[code]/lock-lobby/route.ts
+++ b/src/app/api/games/[code]/lock-lobby/route.ts
@@ -1,23 +1,24 @@
-import { NextResponse, type NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
 import { getSession } from '@/app/api/games/_session'
 import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(
-  _req: NextRequest,
-  { params }: { params: { code: string } }
+  _req: Request,
+  ctx: { params: Promise<{ code: string }> }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const code = params.code.toUpperCase()
+  const { code } = await ctx.params
+  const gameCode = code.toUpperCase()
   const s = supabaseServer(session.access_token)
 
   const { error } = await s
     .from('herd_games')
     .update({ lobby_locked: true })
-    .eq('code', code)
+    .eq('code', gameCode)
     .eq('owner_id', session.user.id)
 
   if (error) return NextResponse.json({ error: error.message }, { status: 400 })

--- a/src/app/api/games/[code]/players/route.ts
+++ b/src/app/api/games/[code]/players/route.ts
@@ -1,5 +1,5 @@
 // PATH: src/app/api/games/[code]/players/route.ts
-import { NextResponse, type NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
 import { supabaseServer } from '@/integrations/supabase/server'
 import { randomUUID } from 'crypto'
 
@@ -14,10 +14,11 @@ type Participant = {
 
 // GET – vráti lobby (zoznam hráčov)
 export async function GET(
-  _req: NextRequest,
-  { params }: { params: { code: string } }
+  _req: Request,
+  ctx: { params: Promise<{ code: string }> }
 ) {
-  const gameCode = String(params.code).toUpperCase()
+  const { code } = await ctx.params
+  const gameCode = String(code).toUpperCase()
 
   const supabase = supabaseServer()
 
@@ -58,10 +59,11 @@ export async function GET(
 
 // POST – pridá hráča (kým je lobby otvorená)
 export async function POST(
-  req: NextRequest,
-  { params }: { params: { code: string } }
+  req: Request,
+  ctx: { params: Promise<{ code: string }> }
 ) {
-  const gameCode = String(params.code).toUpperCase()
+  const { code } = await ctx.params
+  const gameCode = String(code).toUpperCase()
 
   const body = (await req.json().catch(() => ({}))) as {
     name?: string

--- a/src/app/api/games/[code]/rounds/[roundId]/question/route.ts
+++ b/src/app/api/games/[code]/rounds/[roundId]/question/route.ts
@@ -1,5 +1,5 @@
 // PATH: src/app/api/games/[code]/rounds/[roundId]/question/route.ts
-import { NextResponse, type NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
 import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
@@ -12,11 +12,12 @@ type FourAnswers = {
 }
 
 export async function GET(
-  req: NextRequest,
-  { params }: { params: { code: string; roundId: string } }
+  req: Request,
+  ctx: { params: Promise<{ code: string; roundId: string }> }
 ) {
-  const code = String(params.code).toUpperCase()
-  const roundId = String(params.roundId)
+  const { code, roundId } = await ctx.params
+  const gameCode = String(code).toUpperCase()
+  const rId = String(roundId)
 
   const url = new URL(req.url)
   const qIndexParam = url.searchParams.get('qIndex')
@@ -26,8 +27,8 @@ export async function GET(
   const { data: round } = await s
     .from('herd_rounds')
     .select('q_index, status, settings')
-    .eq('id', roundId)
-    .eq('game_code', code)
+    .eq('id', rId)
+    .eq('game_code', gameCode)
     .single()
 
   if (!round) {

--- a/src/app/api/games/[code]/rounds/config/route.ts
+++ b/src/app/api/games/[code]/rounds/config/route.ts
@@ -1,17 +1,18 @@
 // PATH: src/app/api/games/[code]/rounds/config/route.ts
-import { NextResponse, type NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
 import { supabaseServer } from '@/integrations/supabase/server'
 import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(
-  req: NextRequest,
-  { params }: { params: { code: string } }
+  req: Request,
+  ctx: { params: Promise<{ code: string }> }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const code = String(params.code).toUpperCase()
+  const { code } = await ctx.params
+  const gameCode = String(code).toUpperCase()
 
   // bezpečné načítanie body
   const body = await req.json().catch(() => ({} as any))
@@ -24,7 +25,7 @@ export async function POST(
     .from('herd_rounds')
     .upsert(
       {
-        game_code: code,
+        game_code: gameCode,
         idx: index,
         category: categoryId,
         count: questions,
@@ -43,18 +44,18 @@ export async function POST(
   }
 
   // udržujeme phase v herd_games
-  await s.from('herd_games').update({ phase: 'round_setup' }).eq('code', code)
+  await s.from('herd_games').update({ phase: 'round_setup' }).eq('code', gameCode)
 
   // voliteľne: ak je to posledné potvrdené kolo, prepneme hru do "ready"
   try {
-    const g = await s.from('herd_games').select('total_rounds').eq('code', code).single()
+    const g = await s.from('herd_games').select('total_rounds').eq('code', gameCode).single()
     const have = await s
       .from('herd_rounds')
       .select('idx', { count: 'exact', head: true })
-      .eq('game_code', code)
+      .eq('game_code', gameCode)
 
     if (!g.error && !have.error && (have.count ?? 0) >= (g.data?.total_rounds ?? 0)) {
-      await s.from('herd_games').update({ phase: 'ready' }).eq('code', code)
+      await s.from('herd_games').update({ phase: 'ready' }).eq('code', gameCode)
     }
   } catch {
     // nič – len nech to nepadne, keď typy/kolónky chýbajú

--- a/src/app/api/games/[code]/rounds/lock/route.ts
+++ b/src/app/api/games/[code]/rounds/lock/route.ts
@@ -1,5 +1,5 @@
 // PATH: src/app/api/games/[code]/rounds/lock/route.ts
-import { NextResponse, type NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
 import { RealtimeServer } from '@/lib/realtime/server'
 import { channelFor } from '@/lib/realtime/types'
 import { supabaseServer } from '@/integrations/supabase/server'
@@ -8,13 +8,14 @@ import { getSession } from '@/app/api/games/_session'
 export const dynamic = 'force-dynamic'
 
 export async function POST(
-  req: NextRequest,
-  { params }: { params: { code: string } }
+  req: Request,
+  ctx: { params: Promise<{ code: string }> }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const code = String(params.code).toUpperCase()
+  const { code } = await ctx.params
+  const gameCode = String(code).toUpperCase()
   const body = await req.json().catch(() => ({})) as { roundId?: string }
 
   const s = supabaseServer(session.access_token)
@@ -25,7 +26,7 @@ export async function POST(
     const { data: running } = await s
       .from('herd_rounds')
       .select('id, q_index')
-      .eq('game_code', code)
+      .eq('game_code', gameCode)
       .eq('status', 'running')
       .single()
     if (!running) {
@@ -38,7 +39,7 @@ export async function POST(
     .from('herd_rounds')
     .select('id, q_index, status')
     .eq('id', roundId)
-    .eq('game_code', code)
+    .eq('game_code', gameCode)
     .single()
 
 
@@ -51,9 +52,9 @@ export async function POST(
     .update({ status: 'locked' })
     .eq('id', round.id)
 
-  await RealtimeServer.publish(channelFor(code), {
+  await RealtimeServer.publish(channelFor(gameCode), {
     type: 'round:lock',
-    code,
+    code: gameCode,
     roundId: round.id,
     qIndex: round.q_index || 0,
     at: Date.now(),

--- a/src/app/api/games/[code]/rounds/next/route.ts
+++ b/src/app/api/games/[code]/rounds/next/route.ts
@@ -1,5 +1,5 @@
 // PATH: src/app/api/games/[code]/rounds/next/route.ts
-import { NextResponse, type NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
 import { RealtimeServer } from '@/lib/realtime/server'
 import { channelFor } from '@/lib/realtime/types'
 import { supabaseServer } from '@/integrations/supabase/server'
@@ -8,13 +8,14 @@ import { getSession } from '@/app/api/games/_session'
 export const dynamic = 'force-dynamic'
 
 export async function POST(
-  req: NextRequest,
-  { params }: { params: { code: string } }
+  req: Request,
+  ctx: { params: Promise<{ code: string }> }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const code = String(params.code).toUpperCase()
+  const { code } = await ctx.params
+  const gameCode = String(code).toUpperCase()
 
   const body = await req.json().catch(() => ({})) as { roundId?: string }
   const s = supabaseServer(session.access_token)
@@ -25,7 +26,7 @@ export async function POST(
     const { data: resRound } = await s
       .from('herd_rounds')
       .select('id, q_index, settings')
-      .eq('game_code', code)
+      .eq('game_code', gameCode)
       .eq('status', 'results')
       .single()
     if (!resRound) {
@@ -38,7 +39,7 @@ export async function POST(
     .from('herd_rounds')
     .select('id, q_index, status, settings')
     .eq('id', roundId)
-    .eq('game_code', code)
+    .eq('game_code', gameCode)
     .single()
 
   if (!round || round.status !== 'results') {
@@ -55,12 +56,12 @@ export async function POST(
     const { data: leaderboard } = await s
       .from('herd_players')
       .select('id, name, score')
-      .eq('game_code', code)
+      .eq('game_code', gameCode)
       .order('score', { ascending: false })
 
-    await RealtimeServer.publish(channelFor(code), {
+    await RealtimeServer.publish(channelFor(gameCode), {
       type: 'round:finish',
-      code,
+      code: gameCode,
       roundId: round.id,
       leaderboard,
       at: Date.now(),
@@ -79,9 +80,9 @@ export async function POST(
     .update({ q_index: nextQIndex, status: 'shown' })
     .eq('id', round.id)
 
-  await RealtimeServer.publish(channelFor(code), {
+  await RealtimeServer.publish(channelFor(gameCode), {
     type: 'game:start',
-    code,
+    code: gameCode,
     roundId: round.id,
     qIndex: nextQIndex,
     at: Date.now(),

--- a/src/app/api/games/[code]/rounds/results/route.ts
+++ b/src/app/api/games/[code]/rounds/results/route.ts
@@ -1,5 +1,5 @@
 // PATH: src/app/api/games/[code]/rounds/results/route.ts
-import { NextResponse, type NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
 import { RealtimeServer } from '@/lib/realtime/server'
 import { channelFor } from '@/lib/realtime/types'
 import { calculateRoundScores } from '@/lib/herdvote/scoring'
@@ -9,12 +9,13 @@ import { getSession } from '@/app/api/games/_session'
 export const dynamic = 'force-dynamic'
 
 export async function POST(
-  req: NextRequest,
-  { params }: { params: { code: string } }
+  req: Request,
+  ctx: { params: Promise<{ code: string }> }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const code = String(params.code).toUpperCase()
+  const { code } = await ctx.params
+  const gameCode = String(code).toUpperCase()
 
   const body = await req.json().catch(() => ({})) as { roundId?: string }
 
@@ -26,7 +27,7 @@ export async function POST(
     const { data: locked } = await s
       .from('herd_rounds')
       .select('id, q_index, settings')
-      .eq('game_code', code)
+      .eq('game_code', gameCode)
       .eq('status', 'locked')
       .single()
     if (!locked) {
@@ -39,7 +40,7 @@ export async function POST(
     .from('herd_rounds')
     .select('id, q_index, status, settings')
     .eq('id', roundId)
-    .eq('game_code', code)
+    .eq('game_code', gameCode)
     .single()
 
   if (!round || round.status !== 'locked') {
@@ -119,12 +120,12 @@ export async function POST(
   const { data: leaderboard } = await s
     .from('herd_players')
     .select('id, name, score')
-    .eq('game_code', code)
+    .eq('game_code', gameCode)
     .order('score', { ascending: false })
 
-  await RealtimeServer.publish(channelFor(code), {
+  await RealtimeServer.publish(channelFor(gameCode), {
     type: 'round:results',
-    code,
+    code: gameCode,
     roundId: round.id,
     qIndex,
     correct: question.correct_answer as any,

--- a/src/app/api/games/[code]/rounds/route.ts
+++ b/src/app/api/games/[code]/rounds/route.ts
@@ -1,5 +1,5 @@
 // PATH: src/app/api/games/[code]/rounds/route.ts
-import { NextResponse, type NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
 import type { RoundSettings } from '@/lib/herdvote/store'
 import { getSession } from '@/app/api/games/_session'
 import { supabaseServer } from '@/integrations/supabase/server'
@@ -17,12 +17,13 @@ export const dynamic = 'force-dynamic'
  */
 
 export async function POST(
-  req: NextRequest,
-  { params }: { params: { code: string } }
+  req: Request,
+  ctx: { params: Promise<{ code: string }> }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const gameCode = String(params.code).toUpperCase()
+  const { code } = await ctx.params
+  const gameCode = String(code).toUpperCase()
 
   const supabase = supabaseServer(session.access_token)
 

--- a/src/app/api/games/[code]/rounds/start/route.ts
+++ b/src/app/api/games/[code]/rounds/start/route.ts
@@ -1,17 +1,18 @@
 // PATH: src/app/api/games/[code]/rounds/start/route.ts
-import { NextResponse, type NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
 import { supabaseServer } from '@/integrations/supabase/server'
 import { getSession } from '@/app/api/games/_session'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(
-  req: NextRequest,
-  { params }: { params: { code: string } }
+  req: Request,
+  ctx: { params: Promise<{ code: string }> }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const code = String(params.code).toUpperCase()
+  const { code } = await ctx.params
+  const gameCode = String(code).toUpperCase()
 
   const body = await req.json().catch(() => ({} as any))
   const index = typeof body?.index === 'number' ? body.index : 0
@@ -22,7 +23,7 @@ export async function POST(
   const { data: round, error: roundErr } = await s
     .from('herd_rounds')
     .select('id, category, count, settings')
-    .eq('game_code', code)
+    .eq('game_code', gameCode)
     .eq('idx', index)
     .single()
 
@@ -58,7 +59,7 @@ export async function POST(
   await s
     .from('herd_games')
     .update({ phase: 'playing', active_round_index: index })
-    .eq('code', code)
+    .eq('code', gameCode)
 
   return NextResponse.json({ ok: true, phase: 'playing' })
 }

--- a/src/app/api/games/[code]/rounds/timer/start/route.ts
+++ b/src/app/api/games/[code]/rounds/timer/start/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse, type NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
 import { RealtimeServer } from '@/lib/realtime/server'
 import { channelFor } from '@/lib/realtime/types'
 import { supabaseServer } from '@/integrations/supabase/server'
@@ -7,13 +7,14 @@ import { getSession } from '@/app/api/games/_session'
 export const dynamic = 'force-dynamic'
 
 export async function POST(
-  req: NextRequest,
-  { params }: { params: { code: string } }
+  req: Request,
+  ctx: { params: Promise<{ code: string }> }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const code = String(params.code).toUpperCase()
+  const { code } = await ctx.params
+  const gameCode = String(code).toUpperCase()
 
   const body = await req.json().catch(() => ({})) as {
     seconds?: number
@@ -29,7 +30,7 @@ export async function POST(
     const { data: shown } = await s
       .from('herd_rounds')
       .select('id, q_index')
-      .eq('game_code', code)
+      .eq('game_code', gameCode)
       .eq('status', 'shown')
       .single()
     if (!shown) return NextResponse.json({ error: 'Round not found' }, { status: 404 })
@@ -40,7 +41,7 @@ export async function POST(
     .from('herd_rounds')
     .select('id, q_index, status')
     .eq('id', roundId)
-    .eq('game_code', code)
+    .eq('game_code', gameCode)
     .single()
 
   if (!round || round.status !== 'shown') {
@@ -55,9 +56,9 @@ export async function POST(
     .update({ status: 'running', timer_deadline: deadline })
     .eq('id', round.id)
 
-  await RealtimeServer.publish(channelFor(code), {
+  await RealtimeServer.publish(channelFor(gameCode), {
     type: 'timer:start',
-    code,
+    code: gameCode,
     roundId: round.id,
     qIndex: round.q_index || 0,
     startedAt,

--- a/src/app/api/games/[code]/route.ts
+++ b/src/app/api/games/[code]/route.ts
@@ -1,14 +1,15 @@
-import { NextResponse, type NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
 import { getSession } from '@/app/api/games/_session'
 import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET(
-  _req: NextRequest,
-  { params }: { params: { code: string } }
+  _req: Request,
+  ctx: { params: Promise<{ code: string }> }
 ) {
-  const code = String(params.code).toUpperCase()
+  const { code } = await ctx.params
+  const gameCode = String(code).toUpperCase()
 
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -19,7 +20,7 @@ export async function GET(
   const { data: game, error } = await s
     .from('herd_games')
     .select('code, phase, total_rounds, active_round_index, lobby_locked')
-    .eq('code', code)
+    .eq('code', gameCode)
     .eq('owner_id', session.user.id)
     .single()
 
@@ -30,7 +31,7 @@ export async function GET(
   const { count: roundsCount } = await s
     .from('herd_rounds')
     .select('idx', { count: 'exact', head: true })
-    .eq('game_code', code)
+    .eq('game_code', gameCode)
 
   const phase =
     game.phase === 'setup'

--- a/src/app/api/games/[code]/start/route.ts
+++ b/src/app/api/games/[code]/start/route.ts
@@ -1,23 +1,24 @@
-import { NextResponse, type NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
 import { getSession } from '@/app/api/games/_session'
 import { supabaseServer } from '@/integrations/supabase/server'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(
-  _req: NextRequest,
-  { params }: { params: { code: string } }
+  _req: Request,
+  ctx: { params: Promise<{ code: string }> }
 ) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const code = params.code.toUpperCase()
+  const { code } = await ctx.params
+  const gameCode = code.toUpperCase()
   const s = supabaseServer(session.access_token)
 
   const { error } = await s
     .from('herd_games')
     .update({ phase: 'playing' })
-    .eq('code', code)
+    .eq('code', gameCode)
     .eq('owner_id', session.user.id)
 
   if (error) return NextResponse.json({ error: error.message }, { status: 400 })

--- a/src/app/api/questions/[id]/route.ts
+++ b/src/app/api/questions/[id]/route.ts
@@ -1,15 +1,16 @@
 // src/app/api/questions/[id]/route.ts
-import { NextRequest, NextResponse } from 'next/server'
+import { NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabaseAdmin' // server-side client (service role)
 
 export const dynamic = 'force-dynamic'
 
 export async function GET(
-  _req: NextRequest,
-  { params }: { params: { id: string } }
+  _req: Request,
+  ctx: { params: Promise<{ id: string }> }
 ) {
   try {
-    const questionId = parseInt(String(params.id), 10)
+    const { id } = await ctx.params
+    const questionId = parseInt(String(id), 10)
 
     if (!Number.isFinite(questionId) || questionId <= 0) {
       return NextResponse.json({ error: 'Invalid question ID' }, { status: 400 })


### PR DESCRIPTION
## Summary
- adapt API route handlers to Next.js 15 `ctx.params` Promise style
- replace `NextRequest` with `Request` and await params before use

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aec22b62a883278fad7ba037d228c2