### PR TITLE
fix: handle nullable session

### DIFF
--- a/src/hooks/createUseAuth.tsx
+++ b/src/hooks/createUseAuth.tsx
@@ -24,20 +24,21 @@ export function createUseAuth(client: SupabaseClient, cookieName?: string) {
         setUser(session?.user ?? null)
 
         if (session?.user) {
+          const { id, email } = session.user
           setTimeout(async () => {
             if (false) {
               const { data: profileData } = await client
                 .from('user_profiles')
                 .select('*')
-                .eq('id', session.user.id)
+                .eq('id', id)
                 .single()
 
               if (!profileData) {
                 const { data: inserted } = await client
                   .from('user_profiles')
                   .insert({
-                    id: session.user.id,
-                    email: session.user.email ?? '',
+                    id,
+                    email: email ?? '',
                     paid_access: false,
                     daily_questions_date: null,
                     daily_questions_used: 0,


### PR DESCRIPTION
## Summary
- avoid nullable session usage in auth hook

## Testing
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aecea28080832788f26950e73ca3f7