### PR TITLE
fix: guard against missing user

### DIFF
--- a/src/components/LegacyApp.tsx
+++ b/src/components/LegacyApp.tsx
@@ -59,43 +59,44 @@ const router = useRouter()
     setQuestionCounts(counts)
   }
 
-  const loadFavorites = async () => {
-    if (!group || !user) return
+    const loadFavorites = async () => {
+      const uid = user?.id
+      if (!group || !uid) return
 
-    const groupKey = group as GroupKey
+      const groupKey = group as GroupKey
 
-    if (false) {
-      const { data } = await supabase
-        .from('user_favorites')
-        .select(`
-        question_id,
-        questions (
-          id, text, partneri, kamarati, rodina, rodic_dieta
-        )
-      `)
-        // user is guaranteed to be defined here by the guard above
-        .eq('user_id', user!.id)
+      if (false) {
+        const { data } = await supabase
+          .from('user_favorites')
+          .select(`
+          question_id,
+          questions (
+            id, text, partneri, kamarati, rodina, rodic_dieta
+          )
+        `)
+          .eq('user_id', uid)
 
-      const filteredFavorites = data?.filter(
-        (item: any) =>
-          item.questions &&
-          Array.isArray(item.questions) &&
-          item.questions.length > 0 &&
-          item.questions[0][groupKey]
-      ) || []
+        const filteredFavorites =
+          data?.filter(
+            (item: any) =>
+              item.questions &&
+              Array.isArray(item.questions) &&
+              item.questions.length > 0 &&
+              item.questions[0][groupKey]
+          ) || []
 
-      setFavoritesList(filteredFavorites)
-      if (filteredFavorites.length > 0 && filteredFavorites[0]?.questions?.[0]) {
-        setCurrentQuestion(filteredFavorites[0].questions[0])
-        setCurrentFavoriteIndex(0)
+        setFavoritesList(filteredFavorites)
+        if (filteredFavorites.length > 0 && filteredFavorites[0]?.questions?.[0]) {
+          setCurrentQuestion(filteredFavorites[0].questions[0])
+          setCurrentFavoriteIndex(0)
+        } else {
+          setCurrentQuestion(null)
+        }
       } else {
+        setFavoritesList([])
         setCurrentQuestion(null)
       }
-    } else {
-      setFavoritesList([])
-      setCurrentQuestion(null)
     }
-  }
 
   const handleNextQuestion = async () => {
     if (!group) return

--- a/src/hooks/useQuestions.tsx
+++ b/src/hooks/useQuestions.tsx
@@ -35,14 +35,21 @@ export function useQuestions() {
   }, [user])
 
   const fetchUserData = async () => {
-    if (!user) return
+    const uid = user?.id
+    if (!uid) {
+      // Ensure state is reset for guests
+      setViewedQuestions([])
+      setFavorites([])
+      setDailyCount(0)
+      return
+    }
 
     // Fetch viewed questions (disabled until user_question_history exists)
     if (false) {
       const { data: historyData } = await supabase
         .from('user_question_history')
         .select('question_id')
-        .eq('user_id', user.id)
+        .eq('user_id', uid)
 
       if (historyData) {
         setViewedQuestions(historyData.map(h => h.question_id))
@@ -56,7 +63,7 @@ export function useQuestions() {
       const { data: favData } = await supabase
         .from('user_favorites')
         .select('question_id')
-        .eq('user_id', user.id)
+        .eq('user_id', uid)
 
       if (favData) {
         setFavorites(favData.map(f => f.question_id))
@@ -79,7 +86,7 @@ export function useQuestions() {
             daily_questions_date: today,
             daily_questions_used: 0
           })
-          .eq('id', user.id)
+          .eq('id', uid)
       }
     } else {
       setDailyCount(0)
@@ -87,11 +94,12 @@ export function useQuestions() {
   }
 
   const fetchQuestion = async (group: GroupKey, favoritesOnly = false) => {
-    if (!user && !FREE_IDS[group]) return null
+    const uid = user?.id
+    if (!uid && !FREE_IDS[group]) return null
 
     let availableIds: number[] = []
 
-    if (!user) {
+    if (!uid) {
       // Non-authenticated users get free questions
       availableIds = FREE_IDS[group]
     } else if (favoritesOnly) {
@@ -141,13 +149,13 @@ export function useQuestions() {
       .eq('id', randomId)
       .single()
 
-    if (question && user) {
+    if (question && uid) {
       // Mark as viewed (disabled until user_question_history exists)
       if (false) {
         await supabase
           .from('user_question_history')
           .upsert({
-            user_id: user.id,
+            user_id: uid,
             question_id: question.id
           })
       }
@@ -165,7 +173,7 @@ export function useQuestions() {
             .update({
               daily_questions_used: newCount
             })
-            .eq('id', user.id)
+            .eq('id', uid)
         }
       }
     }
@@ -174,16 +182,17 @@ export function useQuestions() {
   }
 
   const toggleFavorite = async (questionId: number) => {
-    if (!user) return
+    const uid = user?.id
+    if (!uid) return
 
     const isFavorite = favorites.includes(questionId)
-    
+
     if (isFavorite) {
       if (false) {
         await supabase
           .from('user_favorites')
           .delete()
-          .eq('user_id', user.id)
+          .eq('user_id', uid)
           .eq('question_id', questionId)
       }
       setFavorites(prev => prev.filter(id => id !== questionId))
@@ -192,7 +201,7 @@ export function useQuestions() {
         await supabase
           .from('user_favorites')
           .insert({
-            user_id: user.id,
+            user_id: uid,
             question_id: questionId
           })
       }


### PR DESCRIPTION
## Summary
- guard against null or missing user IDs in question hooks and legacy favorites

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aed13c32b48327b33f04bca2651f96