### PR TITLE
Fix null handling for Supabase query data in questions hook

### DIFF
--- a/src/hooks/useQuestions.tsx
+++ b/src/hooks/useQuestions.tsx
@@ -46,28 +46,24 @@ export function useQuestions() {
 
     // Fetch viewed questions (disabled until user_question_history exists)
     if (false) {
-      const { data: historyData } = await supabase
+      const { data: historyData = [] } = await supabase
         .from('user_question_history')
         .select('question_id')
         .eq('user_id', uid)
 
-      if (historyData) {
-        setViewedQuestions(historyData.map(h => h.question_id))
-      }
+      setViewedQuestions(historyData.map(h => h.question_id))
     } else {
       setViewedQuestions([])
     }
 
     // Fetch favorites (disabled until user_favorites exists)
     if (false) {
-      const { data: favData } = await supabase
+      const { data: favData = [] } = await supabase
         .from('user_favorites')
         .select('question_id')
         .eq('user_id', uid)
 
-      if (favData) {
-        setFavorites(favData.map(f => f.question_id))
-      }
+      setFavorites(favData.map(f => f.question_id))
     } else {
       setFavorites([])
     }


### PR DESCRIPTION
## Summary
- default Supabase query results to empty arrays in `useQuestions` to satisfy TypeScript null-safety

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aed4e9ae5083278f680bed7ab136da