### PR TITLE
refactor: use phase for herd-vote game state

### DIFF
--- a/src/app/[lang]/apps/herd-vote/AdminWizard.tsx
+++ b/src/app/[lang]/apps/herd-vote/AdminWizard.tsx
@@ -84,16 +84,6 @@ export default function AdminWizard({ code: codeProp }: { code?: string }) {
     }
   }, [])
 
-  function toPhase(status?: string): Phase {
-    switch (status) {
-      case 'lobby': return 'lobby'
-      case 'setup': return 'config'
-      case 'running': return 'playing'
-      case 'ended': return 'final'
-      default: return 'lobby'
-    }
-  }
-
   const refresh = useMemo(() => async () => {
     if (!code) return
     setErr(null)
@@ -103,7 +93,7 @@ export default function AdminWizard({ code: codeProp }: { code?: string }) {
       const raw = await r.json()
       const normalized: Game = {
         code: raw.code ?? code,
-        phase: raw.phase ?? toPhase(raw.status),
+        phase: raw.phase ?? 'lobby',
         lobby_locked: raw.lobby_locked ?? (raw.is_open === false),
         total_rounds: raw.total_rounds ?? raw.roundsCount ?? 3,
         active_round_index: raw.active_round_index ?? raw.activeRoundIndex ?? 0,

--- a/src/app/[lang]/apps/herd-vote/page.tsx
+++ b/src/app/[lang]/apps/herd-vote/page.tsx
@@ -11,12 +11,13 @@ type Category = { id: string; name: string; count: number }
 type Mode = 'classic' | 'podium'
 type GameStatus = 'waiting' | 'configuring' | 'running' | 'finished'
 
-function mapStatus(status: string): GameStatus {
-  const s = status.toLowerCase().trim()
-  if (s === 'lobby') return 'waiting'
-  if (s === 'setup') return 'configuring'
-  if (s === 'running') return 'running'
-  if (s === 'ended') return 'finished'
+function mapPhase(phase: string): GameStatus {
+  const p = phase.toLowerCase().trim()
+  if (p === 'lobby') return 'waiting'
+  if (p === 'setup' || p === 'config' || p === 'round_setup' || p === 'ready' || p === 'locked')
+    return 'configuring'
+  if (p === 'running' || p === 'playing') return 'running'
+  if (p === 'ended' || p === 'final') return 'finished'
   return 'waiting'
 }
 
@@ -119,8 +120,8 @@ export default function HerdVoteAdminPage() {
         }
         if (gr && gr.ok) {
           const gj = await gr.json()
-          if (gj?.status) {
-            setGameStatus(mapStatus(String(gj.status)))
+          if (gj?.phase) {
+            setGameStatus(mapPhase(String(gj.phase)))
 
           }
         }
@@ -316,8 +317,8 @@ export default function HerdVoteAdminPage() {
                   onClick={async () => {
                     const r = await authFetch(`/api/games/${gameCode}/lock-lobby`, { method: 'POST' })
                     const j = await r.json()
-                    if (!r.ok || !j.status) return alert(j.error || 'Nepodarilo sa zamknúť lobby')
-                    setGameStatus(mapStatus(String(j.status)))
+                    if (!r.ok || !j.phase) return alert(j.error || 'Nepodarilo sa zamknúť lobby')
+                    setGameStatus(mapPhase(String(j.phase)))
                   }}
                   className="px-3 py-2 rounded bg-black text-white text-sm"
                 >

--- a/src/app/api/games/[code]/lock-lobby/route.ts
+++ b/src/app/api/games/[code]/lock-lobby/route.ts
@@ -16,10 +16,10 @@ export async function POST(_req: NextRequest, context: any) {
 
   const { error } = await s
     .from('herd_games')
-    .update({ lobby_locked: true })
+    .update({ lobby_locked: true, phase: 'locked' })
     .eq('code', gameCode)
     .eq('owner_id', session.user.id)
 
   if (error) return NextResponse.json({ error: error.message }, { status: 400 })
-  return NextResponse.json({ success: true, status: 'locked' })
+  return NextResponse.json({ success: true, phase: 'locked' })
 }

--- a/src/app/api/games/active/route.ts
+++ b/src/app/api/games/active/route.ts
@@ -20,6 +20,6 @@ export async function GET(_req: NextRequest) {
 
   if (!g) return NextResponse.json({}, { status: 204 })
 
-  return NextResponse.json({ code: g.code, status: g.phase || 'lobby' })
+  return NextResponse.json({ code: g.code, phase: g.phase || 'lobby' })
 }
 


### PR DESCRIPTION
## Summary
- use `phase` instead of `status` in herd-vote admin page
- normalize AdminWizard to rely on `phase`
- expose `phase` from lock-lobby and active game routes

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aefc9e53d08327a9375b0ee9e79139