### PR TITLE
Return setup status when locking lobby

### DIFF
--- a/src/app/[lang]/apps/herd-vote/page.tsx
+++ b/src/app/[lang]/apps/herd-vote/page.tsx
@@ -14,7 +14,7 @@ type GameStatus = 'waiting' | 'configuring' | 'running' | 'finished'
 function mapStatus(status: string): GameStatus {
   const s = status.toLowerCase().trim()
   if (s === 'lobby') return 'waiting'
-  if (s === 'setup') return 'configuring'
+  if (s === 'locked' || s === 'setup') return 'configuring'
   if (s === 'running') return 'running'
   if (s === 'ended') return 'finished'
   return 'waiting'

--- a/src/app/api/games/[code]/lock-lobby/route.ts
+++ b/src/app/api/games/[code]/lock-lobby/route.ts
@@ -21,5 +21,5 @@ export async function POST(_req: NextRequest, context: any) {
     .eq('owner_id', session.user.id)
 
   if (error) return NextResponse.json({ error: error.message }, { status: 400 })
-  return NextResponse.json({ success: true, status: 'locked' })
+  return NextResponse.json({ success: true, status: 'setup' })
 }


### PR DESCRIPTION
## Summary
- Mark herd-vote lobby lock with a `setup` status and flag as configurable
- Recognize both `locked` and `setup` statuses in the admin page and treat them as `configuring`

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aefc9fefac83279a116ba40fd0bc5c