### PR TITLE
refactor: use semantic color tokens

### DIFF
--- a/src/components/GroupCompletionContent.tsx
+++ b/src/components/GroupCompletionContent.tsx
@@ -87,38 +87,38 @@ export default function GroupCompletionContent({
         <div className="text-6xl mb-4">🎉</div>
         <div className="text-4xl mb-4">{content.emoji}</div>
 
-        <h3 className="text-xl font-bold text-gray-800 mb-2">
+        <h3 className="text-xl font-bold text-foreground mb-2">
           {content.title}
         </h3>
-        <p className="text-gray-700 mb-2 font-medium">
+        <p className="text-muted-foreground mb-2 font-medium">
           {content.subtitle}
         </p>
-        <p className="text-gray-600 italic">{content.description}</p>
+        <p className="text-muted-foreground italic">{content.description}</p>
       </div>
 
-      <div className="bg-gradient-to-br from-purple-50 to-pink-50 rounded-lg p-6 text-left">
-        <h4 className="font-semibold text-purple-800 mb-3 text-center">
+      <div className="bg-gradient-to-br from-primary/10 to-accent/10 rounded-lg p-6 text-left">
+        <h4 className="font-semibold text-primary mb-3 text-center">
           ✨ Chceš sa spoznať ešte hlbšie?
         </h4>
-        <p className="text-gray-700 mb-4 text-center">
+        <p className="text-muted-foreground mb-4 text-center">
           Spoznávanie nekončí! 🚀
           <br />
           Získaj neobmedzený prístup k stovkám premyslených otázok, ktoré ti
           pomôžu:
         </p>
-        <ul className="space-y-2 text-gray-700 mb-4">
+        <ul className="space-y-2 text-muted-foreground mb-4">
           {content.benefits.map((benefit, index) => (
             <li key={index} className="flex items-start gap-2">
-              <span className="text-purple-600 mt-1">•</span>
+              <span className="text-primary mt-1">•</span>
               <span>{benefit}</span>
             </li>
           ))}
         </ul>
       </div>
 
-      <div className="bg-gradient-to-r from-amber-50 to-orange-50 rounded-lg p-4 border border-amber-200">
-        <h4 className="font-semibold text-amber-800 mb-2">🎁 Bonus pre nových členov:</h4>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm text-amber-700">
+      <div className="bg-gradient-to-r from-warning/10 to-warning/20 rounded-lg p-4 border border-warning/20">
+        <h4 className="font-semibold text-warning mb-2">🎁 Bonus pre nových členov:</h4>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm text-warning/80">
           <div className="flex items-center gap-2">
             <span>🏅</span>
             <span>Každý deň 2 otázky zadarmo z každej skupiny</span>
@@ -139,12 +139,12 @@ export default function GroupCompletionContent({
       </div>
 
       <div className="space-y-4">
-        <h4 className="font-semibold text-gray-800">🧭 Čo chceš spraviť teraz?</h4>
+        <h4 className="font-semibold text-foreground">🧭 Čo chceš spraviť teraz?</h4>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <Button
             onClick={() => router.push('/upgrade')}
-            className="bg-gradient-to-r from-purple-600 to-pink-600 hover:brightness-110 text-white h-12"
+            className="bg-gradient-to-r from-primary to-accent hover:brightness-110 text-primary-foreground h-12"
           >
             🗝️ Chcem plný prístup
           </Button>
@@ -152,7 +152,7 @@ export default function GroupCompletionContent({
           {!user && (
             <Button
               onClick={() => router.push('/auth/login')}
-              className="bg-gray-100 text-gray-800 hover:bg-gray-200 h-12"
+              className="bg-muted text-foreground hover:bg-muted/80 h-12"
             >
               ✍️ Registrovať sa a získať 2 otázky denne
             </Button>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -39,15 +39,15 @@ export default function Layout({ children }: LayoutProps) {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       {/* Header */}
-      <header className="bg-white shadow-sm border-b">
+      <header className="bg-background shadow-sm border-b">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             {/* Logo */}
             <Link href="/" className="flex items-center gap-2">
-              <Brain className="text-pink-500 h-8 w-8" />
-              <span className="text-xl font-bold text-purple-700">Spoznajme sa</span>
+              <Brain className="text-accent h-8 w-8" />
+              <span className="text-xl font-bold text-primary">Spoznajme sa</span>
             </Link>
 
             {/* Desktop Navigation */}
@@ -71,7 +71,7 @@ export default function Layout({ children }: LayoutProps) {
                 <div className="flex items-center gap-3">
                   <div className="text-sm">
                     <div className="font-medium">{user.email}</div>
-                    <div className="text-gray-500">{isPaid ? '✨ Plný prístup' : '🆓 Základný'}</div>
+                    <div className="text-muted-foreground">{isPaid ? '✨ Plný prístup' : '🆓 Základný'}</div>
                   </div>
                   <Button variant="outline" size="sm" onClick={handleSignOut}>
                     <LogOut className="h-4 w-4" />
@@ -102,7 +102,7 @@ export default function Layout({ children }: LayoutProps) {
 
         {/* Mobile Menu */}
         {mobileMenuOpen && (
-          <div className="md:hidden bg-white border-t">
+          <div className="md:hidden bg-background border-t">
             <div className="px-4 py-2 space-y-2">
               {menuItems.map((item) => (
                 <Button

--- a/src/components/LegacyApp.tsx
+++ b/src/components/LegacyApp.tsx
@@ -172,8 +172,8 @@ const router = useRouter()
       <Layout>
         <div className="flex items-center justify-center min-h-[50vh]">
           <div className="text-center">
-            <Brain className="animate-spin h-8 w-8 mx-auto mb-4 text-purple-600" />
-            <p className="text-gray-600">Načítavam...</p>
+            <Brain className="animate-spin h-8 w-8 mx-auto mb-4 text-primary" />
+            <p className="text-muted-foreground">Načítavam...</p>
           </div>
         </div>
       </Layout>
@@ -183,20 +183,20 @@ const router = useRouter()
   return (
     <Layout>
       <div className="max-w-4xl mx-auto px-4 py-8">
-        <div className="bg-white shadow-xl rounded-2xl overflow-hidden">
-          <div className="bg-gradient-to-r from-purple-600 to-pink-600 text-white p-6">
+        <div className="bg-card shadow-xl rounded-2xl overflow-hidden">
+          <div className="bg-gradient-to-r from-primary to-accent text-primary-foreground p-6">
             <div className="flex items-center justify-between">
               <div>
                 <h1 className="text-2xl md:text-3xl font-bold mb-2">
                   {group ? groupLabels[group] : 'Vyber si skupinu'}
                 </h1>
                 {user && (
-                  <div className="text-purple-100 text-sm">
+                  <div className="text-primary-foreground/80 text-sm">
                     {isPaid ? (
                       <div className="flex items-center gap-4">
                         <span>✨ Plný prístup</span>
                         {group && !favoritesMode && (
-                          <span className="flex items-center gap-1">
+                        <span className="flex items-center gap-1">
                             <BarChart3 className="h-4 w-4" />
                             Zostáva: {questionCounts.remaining}/{questionCounts.total}
                           </span>
@@ -216,7 +216,7 @@ const router = useRouter()
                       variant={favoritesMode ? "secondary" : "outline"}
                       size="sm"
                       onClick={handleFavoritesToggle}
-                      className="bg-white/20 hover:bg-white/30 text-white border-white/30"
+                      className="bg-primary-foreground/20 hover:bg-primary-foreground/30 text-primary-foreground border-primary-foreground/30"
                     >
                       <Heart className="h-4 w-4 mr-1" />
                       Obľúbené
@@ -230,7 +230,7 @@ const router = useRouter()
                       setCurrentQuestion(null)
                       setFavoritesMode(false)
                     }}
-                    className="bg-white/20 hover:bg-white/30 text-white border-white/30"
+                    className="bg-primary-foreground/20 hover:bg-primary-foreground/30 text-primary-foreground border-primary-foreground/30"
                   >
                     Zmeniť skupinu
                   </Button>
@@ -242,7 +242,7 @@ const router = useRouter()
           <div className="p-6 md:p-8">
             {!group ? (
               <div className="space-y-6">
-                <p className="text-gray-600 text-center text-lg">
+                <p className="text-muted-foreground text-center text-lg">
                   S kým sa chceš lepšie spoznať?
                 </p>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -250,7 +250,7 @@ const router = useRouter()
                     <Button
                       key={option}
                       onClick={() => handleGroupSelect(option)}
-                      className="h-16 text-lg bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white"
+                      className="h-16 text-lg bg-gradient-to-r from-primary to-accent hover:from-primary/90 hover:to-accent/90 text-primary-foreground"
                       disabled={isLoading}
                     >
                       {groupLabels[option]}
@@ -258,9 +258,9 @@ const router = useRouter()
                   ))}
                 </div>
                 {!user && (
-                  <div className="mt-8 p-4 bg-blue-50 rounded-lg border border-blue-200">
-                    <h3 className="font-semibold text-blue-900 mb-2">💡 Tip</h3>
-                    <p className="text-blue-800 text-sm">
+                  <div className="mt-8 p-4 bg-primary/10 rounded-lg border border-primary/20">
+                    <h3 className="font-semibold text-primary mb-2">💡 Tip</h3>
+                    <p className="text-primary/80 text-sm">
                       Prihlás sa a získaj každý deň 2 nové otázky zo každej skupiny ZADARMO!
                       Plus možnosť označiť si obľúbené otázky.
                     </p>
@@ -278,8 +278,8 @@ const router = useRouter()
             ) : currentQuestion ? (
               <div className="space-y-6">
                 <div className="text-center">
-                  <div className="bg-gray-50 rounded-lg p-6 md:p-8">
-                    <p className="text-lg md:text-xl font-medium text-gray-800 leading-relaxed">
+                  <div className="bg-muted rounded-lg p-6 md:p-8">
+                    <p className="text-lg md:text-xl font-medium text-foreground leading-relaxed">
                       {currentQuestion.text}
                     </p>
                   </div>
@@ -291,7 +291,7 @@ const router = useRouter()
                       <Button variant="outline" size="sm" onClick={handlePrevQuestion}>
                         <ChevronLeft className="h-4 w-4" />
                       </Button>
-                      <span className="text-sm text-gray-600 px-3">
+                      <span className="text-sm text-muted-foreground px-3">
                         {currentFavoriteIndex + 1} / {favoritesList.length}
                       </span>
                       <Button variant="outline" size="sm" onClick={handleNextQuestion}>
@@ -302,7 +302,7 @@ const router = useRouter()
                     <Button
                       onClick={handleNextQuestion}
                       disabled={isLoading || (!user && !canViewMore)}
-                      className="bg-purple-600 hover:bg-purple-700"
+                      className="bg-primary hover:bg-primary/90"
                     >
                       {isLoading ? 'Načítavam...' : 'Ďalšia otázka'}
                     </Button>
@@ -315,13 +315,13 @@ const router = useRouter()
                       onClick={() => toggleFavorite(currentQuestion.id)}
                       className={`flex items-center gap-2 ${
                         favorites.includes(currentQuestion.id)
-                          ? 'text-red-600 border-red-300'
-                          : 'text-gray-600'
+                          ? 'text-destructive border-destructive/30'
+                          : 'text-muted-foreground'
                       }`}
                     >
                       <Heart
                         className={`h-4 w-4 ${
-                          favorites.includes(currentQuestion.id) ? 'fill-red-600' : ''
+                          favorites.includes(currentQuestion.id) ? 'fill-destructive' : ''
                         }`}
                       />
                       {favorites.includes(currentQuestion.id) ? 'Obľúbené' : 'Pridať k obľúbeným'}
@@ -330,13 +330,13 @@ const router = useRouter()
                 </div>
 
                 {!user && (
-                  <div className="text-center p-4 bg-yellow-50 rounded-lg border border-yellow-200">
-                    <p className="text-yellow-800 text-sm">
+                  <div className="text-center p-4 bg-warning/10 rounded-lg border border-warning/20">
+                    <p className="text-warning text-sm">
                       🎁 Vidíš otázky zadarmo! Pre viac funkcií sa
                       <Button
                         variant="link"
                         size="sm"
-                        className="text-yellow-800 underline px-1"
+                        className="text-warning underline px-1"
                         onClick={() => router.push('/auth/login')}
                       >
                         prihlás
@@ -345,7 +345,7 @@ const router = useRouter()
                       <Button
                         variant="link"
                         size="sm"
-                        className="text-yellow-800 underline px-1"
+                        className="text-warning underline px-1"
                         onClick={() => router.push('/upgrade')}
                       >
                         kúp plný prístup

--- a/src/components/hadacka/GameView.tsx
+++ b/src/components/hadacka/GameView.tsx
@@ -135,9 +135,9 @@ export function GameView() {
             <div className="space-y-4">
               {sortedEntities.slice(0, 3).map((entity, index) => (
                 <div key={entity.id} className={`flex items-center justify-center gap-4 p-4 rounded-lg ${
-                  index === 0 ? 'bg-yellow-100 dark:bg-yellow-900/20' :
-                  index === 1 ? 'bg-gray-100 dark:bg-gray-800/20' :
-                  'bg-amber-100 dark:bg-amber-900/20'
+                  index === 0 ? 'bg-warning/20 dark:bg-warning/20' :
+                  index === 1 ? 'bg-muted dark:bg-muted/20' :
+                  'bg-warning/10 dark:bg-warning/20'
                 }`}>
                   <span className="text-2xl">
                     {index === 0 ? '🥇' : index === 1 ? '🥈' : '🥉'}

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -46,7 +46,7 @@ export default function Hero({ lang }: { lang: string }) {
         <div className="relative animate-slide-up">
           <div className="card-connection p-8 space-y-6">
             <div className="flex items-center gap-3">
-              <div className="h-3 w-3 rounded-full bg-green-500 animate-pulse-connection"></div>
+              <div className="h-3 w-3 rounded-full bg-success animate-pulse-connection"></div>
               <span className="text-sm font-medium text-muted-foreground">
                 {t("hero.sample.label", "Ukážka otázky")}
               </span>


### PR DESCRIPTION
## Summary
- replace fixed color utilities with semantic Tailwind tokens in core components
- swap hard-coded gradients and backgrounds for CSS variable-based colors
- update game and hero indicators to use success and warning tokens

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68afd48546088327a9a7f7243d409ff8