### PR TITLE
fix: restore Next.js type references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,8 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
-next-env.d.ts
+# Do not ignore the Next.js type declarations so TypeScript can resolve imports
+!next-env.d.ts
 
 # IDE/editor
 .vscode/

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
## Summary
- keep `next-env.d.ts` under version control so TypeScript resolves image imports
- stop ignoring the file in `.gitignore`

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'next', missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68afd394d1888327aeb990d1cf194c2e