### PR TITLE
Align Herd Vote game flow and admin wizard

### DIFF
--- a/src/app/[lang]/apps/herd-vote/AdminWizard.tsx
+++ b/src/app/[lang]/apps/herd-vote/AdminWizard.tsx
@@ -79,34 +79,7 @@ export default function AdminWizard({ code: codeProp }: { code?: string }) {
     })()
   }, [authFetch])
 
-  // realtime events
-  useEffect(() => {
-    if (!code) return
-    const ch = channelFor(code)
-    const unsub = RealtimeClient.subscribe(ch, ev => {
-      if (ev.type === 'question:show') {
-        setRoundStatus('shown')
-        setGame(g => g ? { ...g, phase: 'playing', timer_deadline: null } : g)
-      }
-      if (ev.type === 'timer:start') {
-        setRoundStatus('running')
-        setGame(g => g ? { ...g, timer_deadline: new Date(ev.startedAt + ev.durationSec * 1000).toISOString() } : g)
-      }
-      if (ev.type === 'round:lock') {
-        setRoundStatus('locked')
-      }
-      if (ev.type === 'round:results') {
-        setRoundStatus('results')
-      }
-      if (ev.type === 'round:finish') {
-        setRoundStatus('finished')
-        refresh()
-      }
-    })
-    return () => unsub()
-  }, [code, refresh])
-
-  const refresh = useMemo(() => async () => {
+  const refresh = useCallback(async () => {
     if (!code) return
     setErr(null)
     try {
@@ -141,7 +114,34 @@ export default function AdminWizard({ code: codeProp }: { code?: string }) {
         }
       } catch {}
     } catch (e:any) { setErr(e?.message ?? 'Chyba') }
-  }, [code])
+  }, [authFetch, code])
+
+  // realtime events
+  useEffect(() => {
+    if (!code) return
+    const ch = channelFor(code)
+    const unsub = RealtimeClient.subscribe(ch, ev => {
+      if (ev.type === 'question:show') {
+        setRoundStatus('shown')
+        setGame(g => g ? { ...g, phase: 'playing', timer_deadline: null } : g)
+      }
+      if (ev.type === 'timer:start') {
+        setRoundStatus('running')
+        setGame(g => g ? { ...g, timer_deadline: new Date(ev.startedAt + ev.durationSec * 1000).toISOString() } : g)
+      }
+      if (ev.type === 'round:lock') {
+        setRoundStatus('locked')
+      }
+      if (ev.type === 'round:results') {
+        setRoundStatus('results')
+      }
+      if (ev.type === 'round:finish') {
+        setRoundStatus('finished')
+        refresh()
+      }
+    })
+    return () => unsub()
+  }, [code, refresh])
 
   useEffect(() => {
     if (transitioning) return

--- a/src/app/[lang]/apps/herd-vote/AdminWizard.tsx
+++ b/src/app/[lang]/apps/herd-vote/AdminWizard.tsx
@@ -1,11 +1,12 @@
 // src/app/[lang]/apps/herd-vote/AdminWizard.tsx
 'use client'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { RealtimeClient } from '@/lib/realtime/client'
+import { channelFor } from '@/lib/realtime/types'
 import { useAuth } from '@/hooks/useAuth'
 
-type Phase =
-  | 'lobby' | 'config' | 'round_setup'
-  | 'playing' | 'locked' | 'reveal' | 'round_results' | 'final'
+type Phase = 'lobby' | 'config' | 'round_setup' | 'playing' | 'final'
+type RoundStatus = 'ready' | 'shown' | 'running' | 'locked' | 'results' | 'finished'
 
 type Game = {
   code: string
@@ -58,7 +59,7 @@ export default function AdminWizard({ code: codeProp }: { code?: string }) {
   const [roundCfg, setRoundCfg] = useState<RoundCfg>({ topic: '', questions: 5 })
   const [players, setPlayers] = useState<{id:string; name:string}[]>([])
   const [categories, setCategories] = useState<Category[]>([])
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [roundStatus, setRoundStatus] = useState<RoundStatus>('ready')
 
   useEffect(() => {
     (async () => {
@@ -78,11 +79,32 @@ export default function AdminWizard({ code: codeProp }: { code?: string }) {
     })()
   }, [authFetch])
 
+  // realtime events
   useEffect(() => {
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current)
-    }
-  }, [])
+    if (!code) return
+    const ch = channelFor(code)
+    const unsub = RealtimeClient.subscribe(ch, ev => {
+      if (ev.type === 'question:show') {
+        setRoundStatus('shown')
+        setGame(g => g ? { ...g, phase: 'playing', timer_deadline: null } : g)
+      }
+      if (ev.type === 'timer:start') {
+        setRoundStatus('running')
+        setGame(g => g ? { ...g, timer_deadline: new Date(ev.startedAt + ev.durationSec * 1000).toISOString() } : g)
+      }
+      if (ev.type === 'round:lock') {
+        setRoundStatus('locked')
+      }
+      if (ev.type === 'round:results') {
+        setRoundStatus('results')
+      }
+      if (ev.type === 'round:finish') {
+        setRoundStatus('finished')
+        refresh()
+      }
+    })
+    return () => unsub()
+  }, [code, refresh])
 
   const refresh = useMemo(() => async () => {
     if (!code) return
@@ -216,12 +238,6 @@ export default function AdminWizard({ code: codeProp }: { code?: string }) {
     if (!code || !g) return
     const seconds = g.question_seconds ?? 45
     await post(`/api/games/${code}/rounds/timer/start`, { seconds })
-    if (timerRef.current) clearTimeout(timerRef.current)
-    timerRef.current = setTimeout(async () => {
-      await post(`/api/games/${code}/rounds/lock`)
-      await post(`/api/games/${code}/rounds/results`)
-      await post(`/api/games/${code}/rounds/next`)
-    }, seconds * 1000)
   }
 
   const joinUrl = useMemo(() => {
@@ -247,7 +263,7 @@ export default function AdminWizard({ code: codeProp }: { code?: string }) {
       {/* KROK 1: Lobby + zamknutie */}
       {g?.phase === 'lobby' && (
         <div className="space-y-2">
-          <div className="text-sm">Zdieľaj link / QR, počkaj na hráčov.</div>
+          <div className="text-sm">Hráči: naskenujte QR alebo otvorte link a zadajte meno.</div>
 
           <div className="flex flex-wrap items-start gap-4">
             <img
@@ -340,7 +356,7 @@ export default function AdminWizard({ code: codeProp }: { code?: string }) {
       {/* KROK 3: Nastavenie kôl po jednom */}
       {g?.phase === 'round_setup' && (
         <div className="space-y-2">
-          <div className="text-sm">Nastavenie kola {roundIx+1}/{g.total_rounds}</div>
+          <div className="text-sm">Nastavenie kola {roundIx + 1}/{g.total_rounds}</div>
           <div className="flex gap-3 items-end">
             <label className="text-sm">Kategória
               <select className="block border rounded px-2 py-1"
@@ -364,37 +380,57 @@ export default function AdminWizard({ code: codeProp }: { code?: string }) {
                         categoryId: roundCfg.categoryId,
                         questions: roundCfg.questions,
                       })
-                      const last = (roundIx + 1) >= (g.total_rounds || 1)
+                      const last = roundIx >= (g.total_rounds || 1) - 1
                       if (last) {
                         await post(`/api/games/${code}/rounds/start`, { index: 0 })
+                        setGame(g => g ? { ...g, phase: 'playing', active_round_index: 0 } : g)
+                        setRoundStatus('shown')
                       } else {
-                        setRoundIx(x=>x+1)
+                        setRoundIx(x => Math.min(x + 1, (g.total_rounds || 1) - 1))
                         await refresh()
                       }
                     }}>
-              {(roundIx + 1) >= (g.total_rounds || 1) ? 'Ideme hrať' : 'Nastaviť ďalšie kolo'}
+              {roundIx >= (g.total_rounds || 1) - 1 ? 'Ideme hrať' : 'Nastaviť ďalšie kolo'}
             </button>
           </div>
         </div>
       )}
 
       {/* KROK 4: Priebeh kola – odpočet, lock, reveal */}
-      {(g?.phase === 'playing' || g?.phase === 'locked' || g?.phase === 'reveal') && (
+      {g?.phase === 'playing' && (
         <div className="space-y-2">
           <div className="text-sm">
-            Kolo { (g.active_round_index ?? 0)+1 } / {g.total_rounds} • Fáza: <b>{g.phase}</b>
+            Kolo {(g.active_round_index ?? 0) + 1} / {g.total_rounds} • Stav: <b>{roundStatus}</b>
           </div>
           <div className="flex flex-wrap gap-2">
             <button
               className="rounded bg-slate-800 text-white px-3 py-1 disabled:opacity-50"
-              disabled={busy || g.phase !== 'playing'}
+              disabled={busy || roundStatus !== 'shown'}
               onClick={startCountdown}
             >
               Spustiť odpočet
             </button>
-          </div>
-          <div className="text-xs text-muted-foreground">
-            Uzamknutie, vyhodnotenie aj prechod na ďalšiu otázku prebehne automaticky po odpočte.
+            <button
+              className="rounded bg-slate-800 text-white px-3 py-1 disabled:opacity-50"
+              disabled={busy || roundStatus !== 'running'}
+              onClick={() => post(`/api/games/${code}/rounds/lock`)}
+            >
+              Uzamknúť
+            </button>
+            <button
+              className="rounded bg-slate-800 text-white px-3 py-1 disabled:opacity-50"
+              disabled={busy || roundStatus !== 'locked'}
+              onClick={() => post(`/api/games/${code}/rounds/results`)}
+            >
+              Vyhodnotiť
+            </button>
+            <button
+              className="rounded bg-slate-800 text-white px-3 py-1 disabled:opacity-50"
+              disabled={busy || roundStatus !== 'results'}
+              onClick={() => post(`/api/games/${code}/rounds/next`)}
+            >
+              Ďalšia otázka
+            </button>
           </div>
           {g.timer_deadline && (
             <div className="text-xs text-muted-foreground">

--- a/src/app/[lang]/apps/page.tsx
+++ b/src/app/[lang]/apps/page.tsx
@@ -68,7 +68,7 @@ export default async function AppsPage({ params }: P) {
       <section className="py-20 px-4">
         <div className="max-w-6xl mx-auto">
           <div className="grid gap-8 md:grid-cols-2">
-            {categories.map((cat) => 
+            {categories.map((cat) =>
               cat.slugs.map((slug) => {
                 const g = games[slug]
                 const gameImage = imageMap[slug]
@@ -107,6 +107,18 @@ export default async function AppsPage({ params }: P) {
               })
             )}
           </div>
+        </div>
+      </section>
+
+      {/* How to play manual */}
+      <section className="py-16 px-4 border-t">
+        <div className="max-w-4xl mx-auto space-y-4 text-sm">
+          <h2 className="text-2xl font-bold">Ako hrať</h2>
+          <p>
+            Vyberte si hru zo zoznamu a riaďte sa pokynmi na jej stránke. Tímový kvíz{' '}
+            <Link href={`/${lang}/apps/herd-vote`} className="text-blue-600 underline">Herd Vote</Link>
+            {' '}spustíte v prehliadači a hráči sa pripoja cez zdieľaný odkaz alebo QR kód.
+          </p>
         </div>
       </section>
     </div>

--- a/src/app/api/games/[code]/answers/route.ts
+++ b/src/app/api/games/[code]/answers/route.ts
@@ -28,28 +28,38 @@ export async function POST(req: Request) {
 
   const s = supabaseServer()
 
-  const { data: game, error: gErr } = await s
-    .from('herd_games')
-    .select('code')
-    .eq('code', gameCode)
+  const { data: round } = await s
+    .from('herd_rounds')
+    .select('status, q_index')
+    .eq('id', roundId)
+    .eq('game_code', gameCode)
     .maybeSingle()
 
-  if (gErr) return NextResponse.json({ error: gErr.message }, { status: 500 })
-  if (!game) return NextResponse.json({ error: 'Game not found' }, { status: 404 })
+  if (!round || round.status !== 'running' || (round.q_index || 0) !== qIndex) {
+    return NextResponse.json({ error: 'Round not accepting answers' }, { status: 400 })
+  }
 
-  const { error } = await s
+  const { data: existing } = await s
     .from('herd_answers')
-    .upsert(
-      {
-        game_code: gameCode,
-        player_id: playerId,
-        round_id: roundId,
-        q_index: qIndex,
-        answer,
-        answered_at: new Date().toISOString(),
-      },
-      { onConflict: 'player_id,round_id,q_index' }
-    )
+    .select('player_id')
+    .eq('game_code', gameCode)
+    .eq('player_id', playerId)
+    .eq('round_id', roundId)
+    .eq('q_index', qIndex)
+    .maybeSingle()
+
+  if (existing) {
+    return NextResponse.json({ ok: true, ignored: true })
+  }
+
+  const { error } = await s.from('herd_answers').insert({
+    game_code: gameCode,
+    player_id: playerId,
+    round_id: roundId,
+    q_index: qIndex,
+    answer,
+    answered_at: new Date().toISOString(),
+  })
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 })

--- a/src/app/api/games/[code]/rounds/config/route.ts
+++ b/src/app/api/games/[code]/rounds/config/route.ts
@@ -33,7 +33,7 @@ export async function POST(req: NextRequest, context: any) {
         prep_seconds: prepSeconds,
         question_seconds: questionSeconds,
         scoring_mode: scoringMode,
-        status: 'setup',
+        status: 'ready',
       },
       { onConflict: 'game_code,idx' }
     )
@@ -47,21 +47,6 @@ export async function POST(req: NextRequest, context: any) {
 
   // udržujeme phase v herd_games
   await s.from('herd_games').update({ phase: 'round_setup' }).eq('code', gameCode)
-
-  // voliteľne: ak je to posledné potvrdené kolo, prepneme hru do "ready"
-  try {
-    const g = await s.from('herd_games').select('total_rounds').eq('code', gameCode).single()
-    const have = await s
-      .from('herd_rounds')
-      .select('idx', { count: 'exact', head: true })
-      .eq('game_code', gameCode)
-
-    if (!g.error && !have.error && (have.count ?? 0) >= (g.data?.total_rounds ?? 0)) {
-      await s.from('herd_games').update({ phase: 'ready' }).eq('code', gameCode)
-    }
-  } catch {
-    // nič – len nech to nepadne, keď typy/kolónky chýbajú
-  }
 
     return NextResponse.json({ ok: true, roundId: savedRound.id, phase: 'round_setup', savedIndex: index })
 }

--- a/src/app/api/games/[code]/rounds/lock/route.ts
+++ b/src/app/api/games/[code]/rounds/lock/route.ts
@@ -41,8 +41,13 @@ export async function POST(req: NextRequest, context: any) {
     .eq('game_code', gameCode)
     .single()
 
-
-  if (!round || round.status !== 'running') {
+  if (!round) {
+    return NextResponse.json({ error: 'No running round to lock' }, { status: 400 })
+  }
+  if (round.status === 'locked') {
+    return NextResponse.json({ success: true, roundId: round.id, qIndex: round.q_index || 0 })
+  }
+  if (round.status !== 'running') {
     return NextResponse.json({ error: 'No running round to lock' }, { status: 400 })
   }
 

--- a/src/app/api/games/[code]/rounds/next/route.ts
+++ b/src/app/api/games/[code]/rounds/next/route.ts
@@ -41,8 +41,14 @@ export async function POST(req: NextRequest, context: any) {
     .eq('game_code', gameCode)
     .single()
 
-  if (!round || round.status !== 'results') {
-    return NextResponse.json({ error: 'No round in results state' }, { status: 400 })
+  if (!round) {
+    return NextResponse.json({ error: 'Round not found' }, { status: 404 })
+  }
+  if (round.status === 'finished') {
+    return NextResponse.json({ success: true, finished: true, roundId: round.id })
+  }
+  if (round.status !== 'results') {
+    return NextResponse.json({ error: 'Round not in results state' }, { status: 400 })
   }
 
   const currentQIndex = round.q_index || 0
@@ -66,6 +72,16 @@ export async function POST(req: NextRequest, context: any) {
       at: Date.now(),
     })
 
+    const { count: remaining } = await s
+      .from('herd_rounds')
+      .select('id', { count: 'exact', head: true })
+      .eq('game_code', gameCode)
+      .in('status', ['ready', 'shown', 'running', 'locked', 'results'])
+
+    if (!remaining || remaining.count === 0) {
+      await s.from('herd_games').update({ phase: 'final' }).eq('code', gameCode)
+    }
+
     return NextResponse.json({
       success: true,
       roundId: round.id,
@@ -80,7 +96,7 @@ export async function POST(req: NextRequest, context: any) {
     .eq('id', round.id)
 
   await RealtimeServer.publish(channelFor(gameCode), {
-    type: 'game:start',
+    type: 'question:show',
     code: gameCode,
     roundId: round.id,
     qIndex: nextQIndex,

--- a/src/app/api/games/[code]/rounds/next/route.ts
+++ b/src/app/api/games/[code]/rounds/next/route.ts
@@ -78,7 +78,7 @@ export async function POST(req: NextRequest, context: any) {
       .eq('game_code', gameCode)
       .in('status', ['ready', 'shown', 'running', 'locked', 'results'])
 
-    if (!remaining || remaining.count === 0) {
+    if (!remaining || remaining === 0) {
       await s.from('herd_games').update({ phase: 'final' }).eq('code', gameCode)
     }
 

--- a/src/app/api/games/[code]/rounds/results/route.ts
+++ b/src/app/api/games/[code]/rounds/results/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { RealtimeServer } from '@/lib/realtime/server'
 import { channelFor } from '@/lib/realtime/types'
-import { calculateRoundScores } from '@/lib/herdvote/scoring'
+import { calculateRoundScores, mapFromGameScoringMode } from '@/lib/herdvote/scoring'
 import { supabaseServer } from '@/integrations/supabase/server'
 import { getSession } from '@/app/api/games/_session'
 import { asArray } from '@/lib/supabase/safe'
@@ -44,7 +44,13 @@ export async function POST(req: NextRequest, context: any) {
     .eq('game_code', gameCode)
     .maybeSingle()
 
-  if (roundErr || !round || round.status !== 'locked') {
+  if (roundErr || !round) {
+    return NextResponse.json({ error: 'No locked round to evaluate' }, { status: 400 })
+  }
+  if (round.status === 'results') {
+    return NextResponse.json({ success: true })
+  }
+  if (round.status !== 'locked') {
     return NextResponse.json({ error: 'No locked round to evaluate' }, { status: 400 })
   }
 
@@ -84,7 +90,15 @@ export async function POST(req: NextRequest, context: any) {
   }))
 
   const roundSettings = (round.settings as any) ?? {}
-  const scoring = roundSettings.scoring ?? { mode: 'classic', correct: 1, incorrect: 0, none: 0 }
+  let scoring = roundSettings.scoring
+  if (!scoring) {
+    const { data: g } = await s
+      .from('herd_games')
+      .select('scoring_mode')
+      .eq('code', gameCode)
+      .maybeSingle()
+    scoring = mapFromGameScoringMode((g?.scoring_mode as any) ?? 'simple')
+  }
 
   const questionScores = calculateRoundScores(
     playerAnswers,

--- a/src/app/api/games/[code]/rounds/start/route.ts
+++ b/src/app/api/games/[code]/rounds/start/route.ts
@@ -1,6 +1,8 @@
 // PATH: src/app/api/games/[code]/rounds/start/route.ts
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
+import { RealtimeServer } from '@/lib/realtime/server'
+import { channelFor } from '@/lib/realtime/types'
 import { supabaseServer } from '@/integrations/supabase/server'
 import { getSession } from '@/app/api/games/_session'
 import { asArray } from '@/lib/supabase/safe'
@@ -61,6 +63,14 @@ export async function POST(req: NextRequest, context: any) {
     .from('herd_games')
     .update({ phase: 'playing', active_round_index: index })
     .eq('code', gameCode)
+
+  await RealtimeServer.publish(channelFor(gameCode), {
+    type: 'question:show',
+    code: gameCode,
+    roundId: round.id,
+    qIndex: 0,
+    at: Date.now(),
+  })
 
   return NextResponse.json({ ok: true, phase: 'playing' })
 }

--- a/src/app/api/games/active/route.ts
+++ b/src/app/api/games/active/route.ts
@@ -14,6 +14,7 @@ export async function GET(_req: NextRequest) {
     .from('herd_games')
     .select('code, phase, updated_at')
     .eq('owner_id', session.user.id)
+    .in('phase', ['lobby', 'config', 'round_setup', 'playing'])
     .order('updated_at', { ascending: false })
     .limit(1)
     .maybeSingle()

--- a/src/app/play/[code]/page.tsx
+++ b/src/app/play/[code]/page.tsx
@@ -48,23 +48,26 @@ export default function PlayJoinPage() {
     const unsub = RealtimeClient.subscribe(ch, async (ev) => {
       console.log('[PLAYER] Event received:', ev)
       
-      if (ev.type === 'game:start') {
-        // Load the current question
+      if (ev.type === 'question:show') {
         setCurrentRoundId(ev.roundId)
         setSelectedAnswer(null)
         setCorrectAnswer(null)
         setGameState('question')
-        
         try {
           const r = await fetch(`/api/games/${code}/rounds/${ev.roundId}/question?qIndex=${ev.qIndex}`)
           if (r.ok) {
             const questionData = await r.json()
             setCurrentQuestion(questionData)
-            setTimeLeft(questionData.timeLeft || 0)
+            setTimeLeft(0)
           }
         } catch (error) {
           console.error('Failed to load question:', error)
         }
+      }
+
+      if (ev.type === 'timer:start') {
+        setGameState('question')
+        setTimeLeft(ev.durationSec)
       }
       
       if (ev.type === 'round:lock') {

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -19,7 +19,7 @@ export default function SiteHeader({ lang: propLang }: { lang?: string }) {
     { href: `/${l}`,                label: t("nav.home","Domov") },
     { href: `/${l}/produkty`,       label: t("nav.products","Produkty") },
     { href: `/${l}/kompas`,         label: t("nav.tools","Komunikačný kompas") },
-    { href: `/${l}/apps#games`,     label: t("nav.apps","Konverzačné hry") },
+    { href: `/${l}/apps`,     label: t("nav.apps","Konverzačné hry") },
   ]
 
   return (

--- a/src/lib/herdvote/scoring.ts
+++ b/src/lib/herdvote/scoring.ts
@@ -76,3 +76,10 @@ export function calculateRoundScores(
 
   return scores
 }
+
+export function mapFromGameScoringMode(mode: string): ScoringClassic | ScoringPodium {
+  if (mode === 'weighted') {
+    return { mode: 'podium', tiers: [5, 3, 1], incorrect: 0, none: 0 }
+  }
+  return { mode: 'classic', correct: 1, incorrect: 0, none: 0 }
+}

--- a/src/lib/realtime/types.ts
+++ b/src/lib/realtime/types.ts
@@ -3,7 +3,6 @@
 import type { Player } from '../herdvote/store'
 
 export type HerdEvent =
-  | { type: 'game:start'; code: string; roundId: string; qIndex: number; at: number }
   | { type: 'question:show'; code: string; roundId: string; qIndex: number; at: number }
   | { type: 'timer:start';   code: string; roundId: string; qIndex: number; startedAt: number; durationSec: number }
   | { type: 'round:lock';    code: string; roundId: string; qIndex: number; at: number }


### PR DESCRIPTION
## Summary
- standardize round setup API to use `ready` status and publish `question:show` events
- finalize round and question transitions with idempotent endpoints and scoring fallback
- overhaul moderator wizard UI with realtime events and proper round controls
- add "Ako hrať" manual and clean site navigation

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aff2c3aaa083279440264400879e1c