### PR TITLE
Add Kompas audience placeholder pages

### DIFF
--- a/src/app/[lang]/kompas/pary/page.tsx
+++ b/src/app/[lang]/kompas/pary/page.tsx
@@ -1,0 +1,22 @@
+// PATH: src/app/[lang]/kompas/pary/page.tsx
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Komunikačný kompas – Páry | DeepTalks',
+  description:
+    'Vety a minipostupy pre komunikáciu v pároch. Obsah pripravujeme.',
+}
+
+type P = { params: Promise<{ lang: string }> }
+
+export default async function Page({ params }: P) {
+  await params
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-10">
+      <h1 className="text-3xl font-semibold">Komunikačný kompas – Páry</h1>
+      <p className="text-muted-foreground mt-3">
+        Obsah pre toto publikum pripravujeme.
+      </p>
+    </div>
+  )
+}

--- a/src/app/[lang]/kompas/rodic-dieta/page.tsx
+++ b/src/app/[lang]/kompas/rodic-dieta/page.tsx
@@ -1,0 +1,22 @@
+// PATH: src/app/[lang]/kompas/rodic-dieta/page.tsx
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Komunikačný kompas – Rodič–dieťa | DeepTalks',
+  description:
+    'Vety a minipostupy pre komunikáciu medzi rodičom a dieťaťom. Obsah pripravujeme.',
+}
+
+type P = { params: Promise<{ lang: string }> }
+
+export default async function Page({ params }: P) {
+  await params
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-10">
+      <h1 className="text-3xl font-semibold">Komunikačný kompas – Rodič–dieťa</h1>
+      <p className="text-muted-foreground mt-3">
+        Obsah pre toto publikum pripravujeme.
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add placeholder page for `/kompas/rodic-dieta`
- add placeholder page for `/kompas/pary`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing type definition files)*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b00455c93c8327b19553a597e5015c