### PR TITLE
feat: show kompas topics for audiences

### DIFF
--- a/src/app/[lang]/kompas/deti/page.tsx
+++ b/src/app/[lang]/kompas/deti/page.tsx
@@ -1,0 +1,44 @@
+// PATH: src/app/[lang]/kompas/deti/page.tsx
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { KOMPAS_SECTIONS_DETI } from '@/config/kompas-sections'
+
+export const metadata: Metadata = {
+  title: 'Komunikačný kompas – Deti | DeepTalks',
+  description:
+    'Vety a minipostupy pre deti. Vyber si tému.',
+}
+
+type P = { params: Promise<{ lang: string }> }
+
+export default async function Page({ params }: P) {
+  const { lang } = await params
+  const go = (p: string) => `/${lang}${p}`
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-10 space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold">Komunikačný kompas – Deti</h1>
+        <p className="text-muted-foreground max-w-2xl">
+          Krátke, použiteľné vety a kroky pre deti. Otvor tému.
+        </p>
+      </header>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-3">Témy</h2>
+        <div className="grid md:grid-cols-2 gap-3">
+          {KOMPAS_SECTIONS_DETI.map((t) => (
+            <Link
+              key={t.slug}
+              href={go(`/kompas/tema/${t.slug}`)}
+              className="rounded-lg border p-4 hover:bg-muted transition block"
+            >
+              <div className="font-medium">{t.label}</div>
+              <div className="text-sm text-muted-foreground">{t.desc}</div>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/[lang]/kompas/page.tsx
+++ b/src/app/[lang]/kompas/page.tsx
@@ -1,24 +1,12 @@
 ﻿// PATH: src/app/[lang]/kompas/page.tsx
 import Link from "next/link"
+import { KOMPAS_SECTIONS } from "@/config/kompas-sections"
 
 export const metadata = {
   title: "Komunikačný kompas | DeepTalks",
   description:
     "Krátke vety a minipostupy do bežných situácií. Vyber si pre koho alebo otvor tému.",
 }
-
-const topics = [
-  { slug: "otvarace-ritualy",     label: "Začať rozhovor & rituály", desc: "Ľahké vety na úvod, check-iny a drobné rituály spojenia" },
-  { slug: "emocie-a-regulacia",   label: "Emócie & regulácia",       desc: "ako pomenovať pocity, upokojiť sa a pomôcť druhému" },
-  { slug: "hranice-a-dohody",     label: "Hranice & dohody",         desc: "jasné požiadavky, dohody a následky bez kriku" },
-  { slug: "konflikt-a-spolupraca",label: "Konflikt & spolupráca",    desc: "odlišné názory bez hádok, hľadanie riešení" },
-  { slug: "zmeny-a-prechody",     label: "Zmeny & prechody",         desc: "rána, odchody, návraty, nové zvyky – čo povedať" },
-  { slug: "spomienky-a-spojenie", label: "Spomienky & spojenie",     desc: "vďačnosť, oceňovanie, budovanie blízkosti" },
-  { slug: "digitalny-zivot",      label: "Digitálny život",          desc: "obrazovky, dohody a prevencia konfliktov" },
-  { slug: "skola-a-ucenie",       label: "Škola & učenie",           desc: "podpora bez tlaku, motivácia a rutiny" },
-  { slug: "zdravie-a-tazke-temy", label: "Zdravie & ťažké témy",     desc: "choroba, smútok, úzkosť – citlivé, ale praktické vety" },
-  { slug: "identita-a-telo",      label: "Identita & telo",          desc: "sebaobraz, rešpekt a citlivé hranice" },
-]
 
 type P = { params: Promise<{ lang: string }> }
 
@@ -37,7 +25,7 @@ export default async function Page({ params }: P) {
 
       <section>
         <h2 className="text-xl font-semibold mb-3">Pre koho</h2>
-        <div className="grid md:grid-cols-2 gap-4">
+        <div className="grid md:grid-cols-3 gap-4">
           <Link
             href={go("/kompas/rodic-dieta")}
             className="rounded-xl border p-5 hover:bg-muted transition block"
@@ -56,13 +44,22 @@ export default async function Page({ params }: P) {
               Vyjadrenie potrieb, prevencia hádok, zdravý konflikt, rituály spojenia.
             </p>
           </Link>
+          <Link
+            href={go("/kompas/deti")}
+            className="rounded-xl border p-5 hover:bg-muted transition block"
+          >
+            <h3 className="font-medium">Deti</h3>
+            <p className="text-sm text-muted-foreground mt-1">
+              Témy a minipostupy priamo pre deti.
+            </p>
+          </Link>
         </div>
       </section>
 
       <section>
         <h2 className="text-xl font-semibold mb-3">Témy</h2>
         <div className="grid md:grid-cols-2 gap-3">
-          {topics.map((t) => (
+          {KOMPAS_SECTIONS.map((t) => (
             <Link
               key={t.slug}
               href={go(`/kompas/tema/${t.slug}`)}

--- a/src/app/[lang]/kompas/pary/page.tsx
+++ b/src/app/[lang]/kompas/pary/page.tsx
@@ -1,0 +1,44 @@
+// PATH: src/app/[lang]/kompas/pary/page.tsx
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { KOMPAS_SECTIONS_PARY } from '@/config/kompas-sections'
+
+export const metadata: Metadata = {
+  title: 'Komunikačný kompas – Páry | DeepTalks',
+  description:
+    'Vety a minipostupy pre komunikáciu v pároch. Vyberte si tému.',
+}
+
+type P = { params: Promise<{ lang: string }> }
+
+export default async function Page({ params }: P) {
+  const { lang } = await params
+  const go = (p: string) => `/${lang}${p}`
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-10 space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold">Komunikačný kompas – Páry</h1>
+        <p className="text-muted-foreground max-w-2xl">
+          Krátke, použiteľné vety a kroky pre páry. Otvor tému.
+        </p>
+      </header>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-3">Témy</h2>
+        <div className="grid md:grid-cols-2 gap-3">
+          {KOMPAS_SECTIONS_PARY.map((t) => (
+            <Link
+              key={t.slug}
+              href={go(`/kompas/tema/${t.slug}`)}
+              className="rounded-lg border p-4 hover:bg-muted transition block"
+            >
+              <div className="font-medium">{t.label}</div>
+              <div className="text-sm text-muted-foreground">{t.desc}</div>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/[lang]/kompas/rodic-dieta/page.tsx
+++ b/src/app/[lang]/kompas/rodic-dieta/page.tsx
@@ -1,0 +1,44 @@
+// PATH: src/app/[lang]/kompas/rodic-dieta/page.tsx
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { KOMPAS_SECTIONS_RODIC_DIETA } from '@/config/kompas-sections'
+
+export const metadata: Metadata = {
+  title: 'Komunikačný kompas – Rodič–dieťa | DeepTalks',
+  description:
+    'Vety a minipostupy pre komunikáciu medzi rodičom a dieťaťom. Vyber si tému.',
+}
+
+type P = { params: Promise<{ lang: string }> }
+
+export default async function Page({ params }: P) {
+  const { lang } = await params
+  const go = (p: string) => `/${lang}${p}`
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-10 space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold">Komunikačný kompas – Rodič–dieťa</h1>
+        <p className="text-muted-foreground max-w-2xl">
+          Krátke, použiteľné vety a kroky do bežných situácií medzi rodičom a dieťaťom. Otvor tému.
+        </p>
+      </header>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-3">Témy</h2>
+        <div className="grid md:grid-cols-2 gap-3">
+          {KOMPAS_SECTIONS_RODIC_DIETA.map((t) => (
+            <Link
+              key={t.slug}
+              href={go(`/kompas/tema/${t.slug}`)}
+              className="rounded-lg border p-4 hover:bg-muted transition block"
+            >
+              <div className="font-medium">{t.label}</div>
+              <div className="text-sm text-muted-foreground">{t.desc}</div>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/config/kompas-sections.ts
+++ b/src/config/kompas-sections.ts
@@ -1,0 +1,24 @@
+export type KompasSection = { slug: string; label: string; desc: string }
+
+export const KOMPAS_SECTIONS_RODIC_DIETA: KompasSection[] = [
+  { slug: "otvarace-ritualy",     label: "Začať rozhovor & rituály",     desc: "Ľahké vety na úvod, check-iny a drobné rituály spojenia" },
+  { slug: "emocie-a-regulacia",   label: "Emócie & regulácia",           desc: "ako pomenovať pocity, upokojiť sa a pomôcť druhému" },
+  { slug: "hranice-a-dohody",     label: "Hranice & dohody",             desc: "jasné požiadavky, dohody a následky bez kriku" },
+  { slug: "konflikt-a-spolupraca",label: "Konflikt & spolupráca",        desc: "odlišné názory bez hádok, hľadanie riešení" },
+  { slug: "zmeny-a-prechody",     label: "Zmeny & prechody",             desc: "rána, odchody, návraty, nové zvyky – čo povedať" },
+  { slug: "spomienky-a-spojenie", label: "Spomienky & spojenie",         desc: "vďačnosť, oceňovanie, budovanie blízkosti" },
+  { slug: "digitalny-zivot",      label: "Digitálny život",              desc: "obrazovky, dohody a prevencia konfliktov" },
+  { slug: "skola-a-ucenie",       label: "Škola & učenie",               desc: "podpora bez tlaku, motivácia a rutiny" },
+  { slug: "zdravie-a-tazke-temy", label: "Zdravie & ťažké témy",         desc: "choroba, smútok, úzkosť – citlivé, ale praktické vety" },
+  { slug: "identita-a-telo",      label: "Identita & telo",              desc: "sebaobraz, rešpekt a citlivé hranice" },
+]
+
+export const KOMPAS_SECTIONS_PARY: KompasSection[] = [
+  ...KOMPAS_SECTIONS_RODIC_DIETA,
+]
+
+export const KOMPAS_SECTIONS_DETI: KompasSection[] = [
+  ...KOMPAS_SECTIONS_RODIC_DIETA,
+]
+
+export const KOMPAS_SECTIONS = KOMPAS_SECTIONS_RODIC_DIETA


### PR DESCRIPTION
## Summary
- show Komunikacny kompas topics on Rodič–dieťa and Páry pages
- centralize Kompas section list in config and use across Kompas pages
- add Deti audience page with its own Kompas topics

## Testing
- `npm test` *(vitest: not found)*
- `npm run lint` *(next: not found)*
- `npm run typecheck` *(Cannot find type definition file for 'next')*
- `npm install` *(403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68b00455c93c8327b19553a597e5015c