### PR TITLE
feat: add skeleton for Kompas

### DIFF
--- a/src/components/Kompas.tsx
+++ b/src/components/Kompas.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import { useState } from 'react'
+import { KOMPAS_DATA } from '@/data/kompas'
+
+export default function Kompas() {
+  // dynamicky zoznam skupín, tém a podtém
+  const groups = Array.from(new Set(KOMPAS_DATA.map((item) => item.group)))
+  const [selectedGroup, setSelectedGroup] = useState<string | null>(null)
+
+  const topics = selectedGroup
+    ? Array.from(
+        new Set(
+          KOMPAS_DATA.filter((item) => item.group === selectedGroup).map(
+            (item) => item.topic
+          )
+        )
+      )
+    : []
+
+  const [selectedTopic, setSelectedTopic] = useState<string | null>(null)
+
+  const subtopics =
+    selectedGroup && selectedTopic
+      ? KOMPAS_DATA.filter(
+          (item) => item.group === selectedGroup && item.topic === selectedTopic
+        )
+      : []
+
+  return (
+    <div className='container mx-auto py-12 px-4'>
+      <h1 className='text-3xl font-bold text-center mb-8'>Komunikačný kompas</h1>
+      <p className='text-center text-gray-600 mb-12 max-w-2xl mx-auto'>
+        Praktické vety a kroky, keď nevieš, ako začať rozhovor. Vyber si pre koho, zvoľ tému a
+        otvor konkrétnu situáciu.
+      </p>
+
+      {/* Výber skupiny */}
+      <div className='flex flex-wrap justify-center gap-3 mb-8'>
+        {groups.map((group) => (
+          <button
+            key={group}
+            onClick={() => {
+              setSelectedGroup(group)
+              setSelectedTopic(null)
+            }}
+            className={`px-4 py-2 rounded-full border transition ${
+              selectedGroup === group
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-100 hover:bg-gray-200'
+            }`}
+          >
+            {group}
+          </button>
+        ))}
+      </div>
+
+      {/* Výber témy */}
+      {selectedGroup && (
+        <div className='flex flex-wrap justify-center gap-3 mb-8'>
+          {topics.map((topic) => (
+            <button
+              key={topic}
+              onClick={() => setSelectedTopic(topic)}
+              className={`px-4 py-2 rounded-lg border transition ${
+                selectedTopic === topic
+                  ? 'bg-green-600 text-white'
+                  : 'bg-gray-100 hover:bg-gray-200'
+              }`}
+            >
+              {topic}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Výpis subtopics */}
+      {selectedGroup && selectedTopic && (
+        <div className='grid grid-cols-1 md:grid-cols-2 gap-6'>
+          {subtopics.map((item, idx) => (
+            <div
+              key={idx}
+              className='bg-white rounded-xl shadow-md p-6 transition hover:shadow-lg'
+            >
+              <h3 className='text-lg font-semibold mb-4'>{item.subtopic}</h3>
+              {item.phrases.length > 0 ? (
+                <ul className='space-y-2 list-disc list-inside text-gray-700'>
+                  {item.phrases.map((phrase, i) => (
+                    <li key={i}>{phrase}</li>
+                  ))}
+                </ul>
+              ) : (
+                <p className='text-gray-400 italic'>(Obsah zatiaľ čaká na doplnenie)</p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Ak ešte nič nevybral */}
+      {!selectedGroup && (
+        <p className='text-center text-gray-400 mt-12'>
+          Vyber si, s kým chceš lepšie komunikovať 👆
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/data/kompas/citlive-temy.ts
+++ b/src/data/kompas/citlive-temy.ts
@@ -1,0 +1,20 @@
+export const CITLIVE_TEMY = [
+  {
+    group: 'Citlivé témy',
+    topic: 'Ako TO povedať',
+    subtopic: 'Keď niekomu smrdí z úst',
+    phrases: []
+  },
+  {
+    group: 'Citlivé témy',
+    topic: 'Osobná hygiena',
+    subtopic: 'Ako povedať kamarátovi, že potrebuje sprchu',
+    phrases: []
+  },
+  {
+    group: 'Citlivé témy',
+    topic: 'Závislosti & ťažké témy',
+    subtopic: 'Ako otvoriť tému alkoholu',
+    phrases: []
+  }
+]

--- a/src/data/kompas/deti.ts
+++ b/src/data/kompas/deti.ts
@@ -1,0 +1,19 @@
+export const DETI = [
+  {
+    group: 'Deti',
+    topic: 'Čo trápi deti',
+    subtopic: 'Byť vypočutý a braný vážne',
+    phrases: [
+      // … sem vlož body 1–10 z RAW
+    ]
+  },
+  {
+    group: 'Deti',
+    topic: 'Čo trápi deti',
+    subtopic: 'Emócie a regulácia',
+    phrases: [
+      // … body 11–20
+    ]
+  }
+  // Pokračuj až po I) Identita, telo, sexualita, hodnoty
+]

--- a/src/data/kompas/index.ts
+++ b/src/data/kompas/index.ts
@@ -1,0 +1,13 @@
+import { DETI } from './deti'
+import { PARY } from './pary'
+import { PRACA } from './praca'
+import { PRIATELIA } from './priatelia'
+import { CITLIVE_TEMY } from './citlive-temy'
+
+export const KOMPAS_DATA = [
+  ...DETI,
+  ...PARY,
+  ...PRACA,
+  ...PRIATELIA,
+  ...CITLIVE_TEMY
+]

--- a/src/data/kompas/pary.ts
+++ b/src/data/kompas/pary.ts
@@ -1,0 +1,20 @@
+export const PARY = [
+  {
+    group: 'Páry',
+    topic: 'Vzťah & intimita',
+    subtopic: 'Ako riešiť konflikt bez hádky',
+    phrases: []
+  },
+  {
+    group: 'Páry',
+    topic: 'Blízkosť & spojenie',
+    subtopic: 'Ako obnoviť intimitu',
+    phrases: []
+  },
+  {
+    group: 'Páry',
+    topic: 'Hranice & dohody',
+    subtopic: 'Ako nastaviť pravidlá vo vzťahu',
+    phrases: []
+  }
+]

--- a/src/data/kompas/praca.ts
+++ b/src/data/kompas/praca.ts
@@ -1,0 +1,20 @@
+export const PRACA = [
+  {
+    group: 'Práca',
+    topic: 'Ako komunikovať so šéfom',
+    subtopic: 'Ako povedať, že nestíham',
+    phrases: []
+  },
+  {
+    group: 'Práca',
+    topic: 'Ako komunikovať so šéfom',
+    subtopic: 'Ako požiadať o zvýšenie platu',
+    phrases: []
+  },
+  {
+    group: 'Práca',
+    topic: 'Kolegovia & tím',
+    subtopic: 'Ako odmietnuť ďalšiu úlohu',
+    phrases: []
+  }
+]

--- a/src/data/kompas/priatelia.ts
+++ b/src/data/kompas/priatelia.ts
@@ -1,0 +1,20 @@
+export const PRIATELIA = [
+  {
+    group: 'Priatelia',
+    topic: 'Sociálne situácie',
+    subtopic: 'Ako odmietnuť pozvanie',
+    phrases: []
+  },
+  {
+    group: 'Priatelia',
+    topic: 'Ako ukončiť rozhovor',
+    subtopic: 'Ako slušne odísť zo stretnutia',
+    phrases: []
+  },
+  {
+    group: 'Priatelia',
+    topic: 'Ako vyjadriť pochvalu',
+    subtopic: 'Ako podporiť priateľa',
+    phrases: []
+  }
+]


### PR DESCRIPTION
## Summary
- add structured Kompas datasets for children, couples, work, friends and sensitive topics
- introduce KOMPAS_DATA aggregator
- create interactive Kompas component with group/topic filtering and placeholder phrases

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b01116e9408327b7cfecb381c93de3