### PR TITLE
feat: integrate Kompas component across kompas pages

### DIFF
--- a/src/app/[lang]/kompas/deti/page.tsx
+++ b/src/app/[lang]/kompas/deti/page.tsx
@@ -1,7 +1,6 @@
 // PATH: src/app/[lang]/kompas/deti/page.tsx
 import type { Metadata } from 'next'
-import Link from 'next/link'
-import { KOMPAS_SECTIONS_DETI } from '@/config/kompas-sections'
+import Kompas from '@/components/Kompas'
 
 export const metadata: Metadata = {
   title: 'Komunikačný kompas – Deti | DeepTalks',
@@ -9,36 +8,6 @@ export const metadata: Metadata = {
     'Vety a minipostupy pre deti. Vyber si tému.',
 }
 
-type P = { params: Promise<{ lang: string }> }
-
-export default async function Page({ params }: P) {
-  const { lang } = await params
-  const go = (p: string) => `/${lang}${p}`
-
-  return (
-    <div className="mx-auto max-w-6xl px-4 py-10 space-y-8">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-semibold">Komunikačný kompas – Deti</h1>
-        <p className="text-muted-foreground max-w-2xl">
-          Krátke, použiteľné vety a kroky pre deti. Otvor tému.
-        </p>
-      </header>
-
-      <section>
-        <h2 className="text-xl font-semibold mb-3">Témy</h2>
-        <div className="grid md:grid-cols-2 gap-3">
-          {KOMPAS_SECTIONS_DETI.map((t) => (
-            <Link
-              key={t.slug}
-              href={go(`/kompas/tema/${t.slug}`)}
-              className="rounded-lg border p-4 hover:bg-muted transition block"
-            >
-              <div className="font-medium">{t.label}</div>
-              <div className="text-sm text-muted-foreground">{t.desc}</div>
-            </Link>
-          ))}
-        </div>
-      </section>
-    </div>
-  )
+export default function Page() {
+  return <Kompas />
 }

--- a/src/app/[lang]/kompas/page.tsx
+++ b/src/app/[lang]/kompas/page.tsx
@@ -1,6 +1,5 @@
 ﻿// PATH: src/app/[lang]/kompas/page.tsx
-import Link from "next/link"
-import { KOMPAS_SECTIONS } from "@/config/kompas-sections"
+import Kompas from "@/components/Kompas"
 
 export const metadata = {
   title: "Komunikačný kompas | DeepTalks",
@@ -8,69 +7,6 @@ export const metadata = {
     "Krátke vety a minipostupy do bežných situácií. Vyber si pre koho alebo otvor tému.",
 }
 
-type P = { params: Promise<{ lang: string }> }
-
-export default async function Page({ params }: P) {
-  const { lang } = await params
-  const go = (p: string) => `/${lang}${p}`
-
-  return (
-    <div className="mx-auto max-w-6xl px-4 py-10 space-y-8">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-semibold tracking-tight">Komunikačný kompas</h1>
-        <p className="text-muted-foreground max-w-2xl">
-          Krátke, použiteľné vety a kroky do bežných situácií. Vyber si pre koho alebo otvor tému.
-        </p>
-      </header>
-
-      <section>
-        <h2 className="text-xl font-semibold mb-3">Pre koho</h2>
-        <div className="grid md:grid-cols-3 gap-4">
-          <Link
-            href={go("/kompas/rodic-dieta")}
-            className="rounded-xl border p-5 hover:bg-muted transition block"
-          >
-            <h3 className="font-medium">Rodič–dieťa</h3>
-            <p className="text-sm text-muted-foreground mt-1">
-              Emócie, hranice, dohody, zmeny. Primerané veku, bez moralizovania.
-            </p>
-          </Link>
-          <Link
-            href={go("/kompas/pary")}
-            className="rounded-xl border p-5 hover:bg-muted transition block"
-          >
-            <h3 className="font-medium">Páry</h3>
-            <p className="text-sm text-muted-foreground mt-1">
-              Vyjadrenie potrieb, prevencia hádok, zdravý konflikt, rituály spojenia.
-            </p>
-          </Link>
-          <Link
-            href={go("/kompas/deti")}
-            className="rounded-xl border p-5 hover:bg-muted transition block"
-          >
-            <h3 className="font-medium">Deti</h3>
-            <p className="text-sm text-muted-foreground mt-1">
-              Témy a minipostupy priamo pre deti.
-            </p>
-          </Link>
-        </div>
-      </section>
-
-      <section>
-        <h2 className="text-xl font-semibold mb-3">Témy</h2>
-        <div className="grid md:grid-cols-2 gap-3">
-          {KOMPAS_SECTIONS.map((t) => (
-            <Link
-              key={t.slug}
-              href={go(`/kompas/tema/${t.slug}`)}
-              className="rounded-lg border p-4 hover:bg-muted transition block"
-            >
-              <div className="font-medium">{t.label}</div>
-              <div className="text-sm text-muted-foreground">{t.desc}</div>
-            </Link>
-          ))}
-        </div>
-      </section>
-    </div>
-  )
+export default function Page() {
+  return <Kompas />
 }

--- a/src/app/[lang]/kompas/pary/page.tsx
+++ b/src/app/[lang]/kompas/pary/page.tsx
@@ -1,8 +1,6 @@
 // PATH: src/app/[lang]/kompas/pary/page.tsx
 import type { Metadata } from 'next'
-import Link from 'next/link'
-
-import { KOMPAS_SECTIONS_PARY } from '@/config/kompas-sections'
+import Kompas from '@/components/Kompas'
 
 
 export const metadata: Metadata = {
@@ -13,38 +11,6 @@ export const metadata: Metadata = {
 
 }
 
-type P = { params: Promise<{ lang: string }> }
-
-export default async function Page({ params }: P) {
-  const { lang } = await params
-  const go = (p: string) => `/${lang}${p}`
-
-  return (
-    <div className="mx-auto max-w-6xl px-4 py-10 space-y-8">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-semibold">Komunikačný kompas – Páry</h1>
-        <p className="text-muted-foreground max-w-2xl">
-          Krátke, použiteľné vety a kroky pre páry. Otvor tému.
-        </p>
-      </header>
-
-      <section>
-        <h2 className="text-xl font-semibold mb-3">Témy</h2>
-        <div className="grid md:grid-cols-2 gap-3">
-
-          {KOMPAS_SECTIONS_PARY.map((t) => (
-
-            <Link
-              key={t.slug}
-              href={go(`/kompas/tema/${t.slug}`)}
-              className="rounded-lg border p-4 hover:bg-muted transition block"
-            >
-              <div className="font-medium">{t.label}</div>
-              <div className="text-sm text-muted-foreground">{t.desc}</div>
-            </Link>
-          ))}
-        </div>
-      </section>
-    </div>
-  )
+export default function Page() {
+  return <Kompas />
 }

--- a/src/app/[lang]/kompas/rodic-dieta/page.tsx
+++ b/src/app/[lang]/kompas/rodic-dieta/page.tsx
@@ -1,8 +1,6 @@
 // PATH: src/app/[lang]/kompas/rodic-dieta/page.tsx
 import type { Metadata } from 'next'
-
-import Link from 'next/link'
-import { KOMPAS_SECTIONS_RODIC_DIETA } from '@/config/kompas-sections'
+import Kompas from '@/components/Kompas'
 
 
 export const metadata: Metadata = {
@@ -13,39 +11,6 @@ export const metadata: Metadata = {
 
 }
 
-type P = { params: Promise<{ lang: string }> }
-
-export default async function Page({ params }: P) {
-  const { lang } = await params
-  const go = (p: string) => `/${lang}${p}`
-
-  return (
-    <div className="mx-auto max-w-6xl px-4 py-10 space-y-8">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-semibold">Komunikačný kompas – Rodič–dieťa</h1>
-        <p className="text-muted-foreground max-w-2xl">
-          Krátke, použiteľné vety a kroky do bežných situácií medzi rodičom a dieťaťom. Otvor tému.
-        </p>
-      </header>
-
-      <section>
-        <h2 className="text-xl font-semibold mb-3">Témy</h2>
-        <div className="grid md:grid-cols-2 gap-3">
-
-          {KOMPAS_SECTIONS_RODIC_DIETA.map((t) => (
-
-            <Link
-              key={t.slug}
-              href={go(`/kompas/tema/${t.slug}`)}
-              className="rounded-lg border p-4 hover:bg-muted transition block"
-            >
-              <div className="font-medium">{t.label}</div>
-              <div className="text-sm text-muted-foreground">{t.desc}</div>
-            </Link>
-          ))}
-        </div>
-      </section>
-
-    </div>
-  )
+export default function Page() {
+  return <Kompas />
 }

--- a/src/app/[lang]/kompas/temy/page.tsx
+++ b/src/app/[lang]/kompas/temy/page.tsx
@@ -1,32 +1,6 @@
 // PATH: src/app/[lang]/kompas/temy/page.tsx
-import Link from "next/link"
-import { KOMPAS_TOPICS } from "@/config/kompas-topics"
-import { normalizeUrlLocale } from "@/lib/i18n-routing"
+import Kompas from "@/components/Kompas"
 
-type P = { params: Promise<{ lang: string }> }
-
-export default async function Page({ params }: P) {
-  const { lang: raw } = await params
-  const lang = normalizeUrlLocale(raw)
-
-  // Pozn.: useI18n je client hook – na serveri necháme jednoduchý fallback:
-  const t = (key: string, fb: string) => fb
-
-  return (
-    <div className="max-w-6xl mx-auto px-4 py-10">
-      <h1 className="text-3xl font-semibold tracking-tight">Témy</h1>
-      <p className="text-muted-foreground mt-2">Veľký prehľad tém Komunikačného kompasu.</p>
-      <div className="grid mt-6 gap-4 sm:grid-cols-2 md:grid-cols-3">
-        {KOMPAS_TOPICS.map((x) => (
-          <Link
-            key={x.slug}
-            href={`/${lang}/kompas/tema/${x.slug}`}
-            className="rounded-xl border p-5 hover:shadow-sm transition"
-          >
-            <div className="font-medium">{t(x.i18nKey, x.fallback)}</div>
-          </Link>
-        ))}
-      </div>
-    </div>
-  )
+export default function Page() {
+  return <Kompas />
 }


### PR DESCRIPTION
## Summary
- replace static Kompas pages with reusable `<Kompas />` component
- apply new design to Kompas subpages (pary, deti, rodič–dieťa, temy)

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: next: not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'next')*

------
https://chatgpt.com/codex/tasks/task_e_68b01ee95454832794807d84f2d64594