### PR TITLE
Add parent-to-child communication group to Kompas

### DIFF
--- a/src/components/Kompas.tsx
+++ b/src/components/Kompas.tsx
@@ -4,7 +4,8 @@ import { useState } from 'react'
 import { KOMPAS_DATA } from '@/data/kompas'
 
 const groupImages: Record<string, string> = {
-  Deti: '/images/kompas/deti.png',
+  'Rodič → Dieťa': '/images/kompas/rodic-dieta.png',
+  Deti: '/images/kompas/dieta.png',
   Páry: '/images/kompas/pary.png',
   Práca: '/images/kompas/praca.png',
   Priatelia: '/images/kompas/priatelia.png',
@@ -43,7 +44,7 @@ export default function Kompas() {
       </p>
 
       {/* Výber skupiny */}
-      <div className='grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 mb-12'>
+      <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-12'>
         {groups.map((group) => (
           <button
             key={group}
@@ -51,15 +52,17 @@ export default function Kompas() {
               setSelectedGroup(group)
               setSelectedTopic(null)
             }}
-            className={`rounded-xl overflow-hidden shadow hover:shadow-lg transition ${
+            className={`flex flex-col rounded-xl overflow-hidden shadow hover:shadow-lg transition text-left ${
               selectedGroup === group ? 'ring-4 ring-blue-400' : ''
             }`}
           >
-            <img
-              src={groupImages[group] || '/images/kompas/default.png'}
-              alt={group}
-              className='w-full h-40 object-cover'
-            />
+            <div className='w-full aspect-video overflow-hidden'>
+              <img
+                src={groupImages[group] || '/images/kompas/default.png'}
+                alt={group}
+                className='w-full h-full object-cover'
+              />
+            </div>
             <div className='p-3 text-center font-semibold bg-white'>{group}</div>
           </button>
         ))}

--- a/src/data/kompas/index.ts
+++ b/src/data/kompas/index.ts
@@ -1,3 +1,4 @@
+import { RODIC_DIETA } from './rodic-dieta'
 import { DETI } from './deti'
 import { PARY } from './pary'
 import { PRACA } from './praca'
@@ -5,6 +6,7 @@ import { PRIATELIA } from './priatelia'
 import { CITLIVE_TEMY } from './citlive-temy'
 
 export const KOMPAS_DATA = [
+  ...RODIC_DIETA,
   ...DETI,
   ...PARY,
   ...PRACA,

--- a/src/data/kompas/rodic-dieta.ts
+++ b/src/data/kompas/rodic-dieta.ts
@@ -1,0 +1,8 @@
+export const RODIC_DIETA = [
+  {
+    group: 'Rodič → Dieťa',
+    topic: 'Podpora a dôvera',
+    subtopic: 'Ako hovoriť, aby počúvali',
+    phrases: []
+  }
+]


### PR DESCRIPTION
## Summary
- introduce new "Rodič → Dieťa" Kompas group with dedicated image and data seed
- fix Kompas card layout to maintain 16:9 aspect ratio and improve responsiveness across breakpoints

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b02e7e82048327858dcbe91343a584