### PR TITLE
feat: add parent-child dataset and chat training mode

### DIFF
--- a/src/components/Kompas.tsx
+++ b/src/components/Kompas.tsx
@@ -12,6 +12,92 @@ const groupImages: Record<string, string> = {
   'Citlivé témy': '/images/kompas/citlive.png',
 }
 
+interface KompasItem {
+  group: string
+  topic: string
+  subtopic: string
+  phrases: string[]
+}
+
+function SubtopicCard({ item }: { item: KompasItem }) {
+  const [mode, setMode] = useState<'all' | 'step'>('all')
+  const [visibleCount, setVisibleCount] = useState(1)
+
+  const phrasesToShow =
+    mode === 'all' ? item.phrases : item.phrases.slice(0, visibleCount)
+
+  return (
+    <div className='bg-white rounded-xl shadow-md p-6 transition hover:shadow-lg'>
+      <div className='flex justify-between items-center mb-4'>
+        <h3 className='text-xl font-semibold'>{item.subtopic}</h3>
+        <div className='flex gap-2'>
+          <button
+            onClick={() => setMode('all')}
+            className={`px-3 py-1 rounded ${
+              mode === 'all'
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+            }`}
+          >
+            Všetky
+          </button>
+          <button
+            onClick={() => {
+              setMode('step')
+              setVisibleCount(1)
+            }}
+            className={`px-3 py-1 rounded ${
+              mode === 'step'
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+            }`}
+          >
+            Postupne
+          </button>
+        </div>
+      </div>
+
+      {item.phrases.length > 0 ? (
+        <div className='space-y-4'>
+          {phrasesToShow.map((phrase, i) => (
+            <div
+              key={i}
+              className={`flex ${
+                i % 2 === 0 ? 'justify-start' : 'justify-end'
+              }`}
+            >
+              <div
+                className={`max-w-[80%] px-4 py-2 rounded-2xl shadow-sm ${
+                  i % 2 === 0
+                    ? 'bg-blue-100 text-blue-900 rounded-bl-none'
+                    : 'bg-green-100 text-green-900 rounded-br-none'
+                }`}
+              >
+                {phrase}
+              </div>
+            </div>
+          ))}
+
+          {mode === 'step' && visibleCount < item.phrases.length && (
+            <div className='text-center mt-4'>
+              <button
+                onClick={() => setVisibleCount(visibleCount + 1)}
+                className='px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700'
+              >
+                Ďalšia veta →
+              </button>
+            </div>
+          )}
+        </div>
+      ) : (
+        <p className='text-gray-400 italic text-center'>
+          (Obsah zatiaľ čaká na doplnenie)
+        </p>
+      )}
+    </div>
+  )
+}
+
 export default function Kompas() {
   const groups = Array.from(new Set(KOMPAS_DATA.map((item) => item.group)))
   const [selectedGroup, setSelectedGroup] = useState<string | null>(null)
@@ -126,28 +212,9 @@ export default function Kompas() {
             />
           </div>
 
-          <div className='grid grid-cols-1 md:grid-cols-2 gap-6'>
+          <div className='space-y-8'>
             {subtopics.map((item, idx) => (
-              <div
-                key={idx}
-                className='bg-white rounded-xl shadow-md p-6 transition hover:shadow-lg'
-              >
-                <h3 className='text-lg font-semibold mb-4'>{item.subtopic}</h3>
-                {item.phrases.length > 0 ? (
-                  <ul className='space-y-2 text-gray-700'>
-                    {item.phrases.map((phrase, i) => (
-                      <li
-                        key={i}
-                        className='bg-gray-50 p-3 rounded-lg shadow-sm border-l-4 border-blue-400'
-                      >
-                        {phrase}
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <p className='text-gray-400 italic'>(Obsah zatiaľ čaká na doplnenie)</p>
-                )}
-              </div>
+              <SubtopicCard key={idx} item={item} />
             ))}
           </div>
         </div>

--- a/src/data/kompas/citlive-temy.ts
+++ b/src/data/kompas/citlive-temy.ts
@@ -1,20 +1,32 @@
 export const CITLIVE_TEMY = [
   {
     group: 'Citlivé témy',
-    topic: 'Ako TO povedať',
-    subtopic: 'Keď niekomu smrdí z úst',
-    phrases: []
-  },
-  {
-    group: 'Citlivé témy',
     topic: 'Osobná hygiena',
-    subtopic: 'Ako povedať kamarátovi, že potrebuje sprchu',
-    phrases: []
+    subtopic: 'Ako povedať, že niekomu smrdí z úst',
+    phrases: [
+      'Prepáč, je to citlivé, ale chcem ti to povedať úprimne – občas cítiť zápach z tvojich úst.',
+      'Hovorím ti to, lebo by som aj ja chcel, aby mi to niekto povedal.',
+      'Možno by pomohlo cukrík alebo ústna voda.',
+    ],
   },
   {
     group: 'Citlivé témy',
-    topic: 'Závislosti & ťažké témy',
-    subtopic: 'Ako otvoriť tému alkoholu',
-    phrases: []
-  }
+    topic: 'Závislosti',
+    subtopic: 'Ako začať tému alkoholu',
+    phrases: [
+      'Mám obavy, že ti alkohol škodí. Hovorím to, lebo mi na tebe záleží.',
+      'Všímam si, že piješ častejšie ako predtým.',
+      'Chcem, aby si vedel, že som tu, ak budeš chcieť pomoc.',
+    ],
+  },
+  {
+    group: 'Citlivé témy',
+    topic: 'Zdravie & psychika',
+    subtopic: 'Ako sa spýtať, či je niekto v depresii',
+    phrases: [
+      'Máš sa posledné dni ťažko, je to tak?',
+      'Chcem sa uistiť, či si v poriadku.',
+      'Ak potrebuješ, môžem ťa sprevádzať k odborníkovi.',
+    ],
+  },
 ]

--- a/src/data/kompas/pary.ts
+++ b/src/data/kompas/pary.ts
@@ -1,20 +1,42 @@
 export const PARY = [
   {
     group: 'Páry',
-    topic: 'Vzťah & intimita',
-    subtopic: 'Ako riešiť konflikt bez hádky',
-    phrases: []
+    topic: 'Blízkosť & intimita',
+    subtopic: 'Ako obnoviť spojenie',
+    phrases: [
+      'Chýba mi byť ti blízko, poďme si nájsť čas len pre seba.',
+      'Potrebujem viac dotykov a objatí, ako to cítiš ty?',
+      'Môžeme si zaviesť malý rituál len pre nás dvoch?',
+    ],
   },
   {
     group: 'Páry',
-    topic: 'Blízkosť & spojenie',
-    subtopic: 'Ako obnoviť intimitu',
-    phrases: []
+    topic: 'Konflikty',
+    subtopic: 'Ako riešiť hádky zdravšie',
+    phrases: [
+      'Potrebujem si dať pauzu, aby som nevybuchol.',
+      'Poďme sa sústrediť na riešenie, nie na obviňovanie.',
+      'Rozumiem, že si nahnevaný, skúsme si povedať, čo obaja potrebujeme.',
+    ],
   },
   {
     group: 'Páry',
-    topic: 'Hranice & dohody',
-    subtopic: 'Ako nastaviť pravidlá vo vzťahu',
-    phrases: []
-  }
+    topic: 'Spoločné rozhodovanie',
+    subtopic: 'Ako sa dohodnúť na financiách',
+    phrases: [
+      'Navrhujem, aby sme si spísali spoločné výdavky.',
+      'Chcem, aby sme mali obaja pocit spravodlivosti.',
+      'Ako to cítiš ty, čo by sme mali zmeniť?',
+    ],
+  },
+  {
+    group: 'Páry',
+    topic: 'Podpora',
+    subtopic: 'Ako byť tu, keď partner prežíva ťažké obdobie',
+    phrases: [
+      'Som tu pre teba, aj keď nemám riešenie.',
+      'Chceš, aby som počúval, alebo aby som radil?',
+      'Rozumiem, že je to pre teba ťažké.',
+    ],
+  },
 ]

--- a/src/data/kompas/praca.ts
+++ b/src/data/kompas/praca.ts
@@ -1,20 +1,42 @@
 export const PRACA = [
   {
     group: 'Práca',
-    topic: 'Ako komunikovať so šéfom',
+    topic: 'Komunikácia so šéfom',
     subtopic: 'Ako povedať, že nestíham',
-    phrases: []
+    phrases: [
+      'Potrebujem si prejsť priority, aby som to zvládol dobre.',
+      'Ak je toto najdôležitejšie, potrebujem odložiť iné úlohy.',
+      'Chcem urobiť kvalitne, ale potrebujem viac času.',
+    ],
   },
   {
     group: 'Práca',
-    topic: 'Ako komunikovať so šéfom',
+    topic: 'Komunikácia so šéfom',
     subtopic: 'Ako požiadať o zvýšenie platu',
-    phrases: []
+    phrases: [
+      'Moja práca priniesla tieto výsledky: … rád by som otvoril tému platu.',
+      'Aké sú možnosti môjho rastu a odmeny?',
+      'Chcem hovoriť o tom, ako moja práca prispela tímu a firme.',
+    ],
   },
   {
     group: 'Práca',
-    topic: 'Kolegovia & tím',
-    subtopic: 'Ako odmietnuť ďalšiu úlohu',
-    phrases: []
-  }
+    topic: 'Kolegovia',
+    subtopic: 'Ako odmietnuť úlohu od kolegu',
+    phrases: [
+      'Momentálne mám plný kalendár, neviem to prevziať.',
+      'Rád by som pomohol, ale potrebujem dokončiť svoju prácu.',
+      'Navrhujem, aby sme to posunuli niekomu, kto má teraz viac kapacity.',
+    ],
+  },
+  {
+    group: 'Práca',
+    topic: 'Konflikty v tíme',
+    subtopic: 'Ako vyjadriť nesúhlas',
+    phrases: [
+      'Chcem povedať svoj pohľad, nie kritizovať teba.',
+      'Rozumiem, ako to myslíš, ale vidím to inak.',
+      'Navrhujem, aby sme sa pozreli na iné riešenie.',
+    ],
+  },
 ]

--- a/src/data/kompas/priatelia.ts
+++ b/src/data/kompas/priatelia.ts
@@ -3,18 +3,30 @@ export const PRIATELIA = [
     group: 'Priatelia',
     topic: 'Sociálne situácie',
     subtopic: 'Ako odmietnuť pozvanie',
-    phrases: []
+    phrases: [
+      'Ďakujem, ale tentoraz nemôžem.',
+      'Rád prídem nabudúce, teraz to nezvládam.',
+      'Chcem byť úprimný – potrebujem čas pre seba.',
+    ],
   },
   {
     group: 'Priatelia',
-    topic: 'Ako ukončiť rozhovor',
-    subtopic: 'Ako slušne odísť zo stretnutia',
-    phrases: []
+    topic: 'Podpora',
+    subtopic: 'Ako povzbudiť priateľa',
+    phrases: [
+      'Verím v teba, zvládneš to.',
+      'Som tu, ak sa chceš porozprávať.',
+      'Môžem ti nejako prakticky pomôcť?',
+    ],
   },
   {
     group: 'Priatelia',
-    topic: 'Ako vyjadriť pochvalu',
-    subtopic: 'Ako podporiť priateľa',
-    phrases: []
-  }
+    topic: 'Konflikty',
+    subtopic: 'Ako povedať, že mi niečo vadí',
+    phrases: [
+      'Mám ťa rád, ale toto správanie mi ubližuje.',
+      'Chcem ti to povedať, aby sme mali lepší vzťah.',
+      'Skúsme si nájsť riešenie, ktoré bude fungovať pre oboch.',
+    ],
+  },
 ]

--- a/src/data/kompas/rodic-dieta.ts
+++ b/src/data/kompas/rodic-dieta.ts
@@ -1,8 +1,52 @@
 export const RODIC_DIETA = [
   {
     group: 'Rodič → Dieťa',
-    topic: 'Podpora a dôvera',
-    subtopic: 'Ako hovoriť, aby počúvali',
-    phrases: []
-  }
+    topic: 'Začať rozhovor',
+    subtopic: 'Ako sa spýtať dieťaťa na jeho deň',
+    phrases: [
+      'Ako sa dnes máš? Čo ti urobilo radosť?',
+      'Bol dnes niekto, kto ti pomohol alebo koho si ty potešil?',
+      'Čo by si dnes zmenil, keby si mohol?',
+    ],
+  },
+  {
+    group: 'Rodič → Dieťa',
+    topic: 'Emócie & regulácia',
+    subtopic: 'Ako reagovať, keď dieťa plače',
+    phrases: [
+      'Vidím, že ťa to bolí. Som tu s tebou.',
+      'Je v poriadku byť smutný. Chceš, aby som ťa objal?',
+      'Povedz mi, čo potrebuješ teraz odo mňa.',
+    ],
+  },
+  {
+    group: 'Rodič → Dieťa',
+    topic: 'Hranice & dohody',
+    subtopic: 'Ako nastaviť jasné hranice bez kriku',
+    phrases: [
+      'Rozumiem, že sa ti to nepáči, ale dohoda je, že po ôsmej už nejdeme na tablet.',
+      'Nechcem na teba kričať. Potrebujem, aby sme sa na tomto dohodli.',
+      'Keď sa dohodneme, že to dodržíme obaja, bude to spravodlivé.',
+    ],
+  },
+  {
+    group: 'Rodič → Dieťa',
+    topic: 'Škola & výkon',
+    subtopic: 'Ako povzbudzovať bez tlaku',
+    phrases: [
+      'Vidím, že si sa snažil. To je pre mňa dôležité.',
+      'Aj keď to nevyšlo na jednotku, vážim si tvoju snahu.',
+      'Skúsme spolu vymyslieť, čo by ti to uľahčilo nabudúce.',
+    ],
+  },
+  {
+    group: 'Rodič → Dieťa',
+    topic: 'Ťažké situácie',
+    subtopic: 'Ako hovoriť o strachu alebo smútku',
+    phrases: [
+      'Aj ja som niekedy smutný. Je to normálne.',
+      'Môžeme si spolu nakresliť, ako sa cítiš?',
+      'Ak chceš, môžeme si o tom len chvíľu posediať potichu.',
+    ],
+  },
 ]


### PR DESCRIPTION
## Summary
- add complete data sets for parent→child, work, couples, friends and sensitive topics in Kompas
- show subtopics as chat bubbles with option to reveal phrases step-by-step

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b03336b6148327bd804d2eef3a029d