### PR TITLE
Add core quiz UI components

### DIFF
--- a/src/components/quiz/FinalReveal.tsx
+++ b/src/components/quiz/FinalReveal.tsx
@@ -10,8 +10,8 @@ interface FinalRevealProps {
 
 export default function FinalReveal({ players }: FinalRevealProps) {
   const sorted = [...players].sort((a, b) => b.score - a.score)
-
-  if (sorted.length === 0) return null
+  const winner = sorted[0]
+  if (!winner) return null
 
   return (
     <div style={{ padding: '2rem', textAlign: 'center' }}>
@@ -20,7 +20,7 @@ export default function FinalReveal({ players }: FinalRevealProps) {
       <h1
         style={{ fontSize: '2.5rem', margin: '1rem 0', color: '#1e90ff' }}
       >
-        🏆 {sorted[0].name}
+        🏆 {winner.name}
       </h1>
 
       <ul style={{ listStyle: 'none', padding: 0 }}>

--- a/src/components/quiz/FinalReveal.tsx
+++ b/src/components/quiz/FinalReveal.tsx
@@ -1,0 +1,40 @@
+interface Player {
+  id: string
+  name: string
+  score: number
+}
+
+interface FinalRevealProps {
+  players: Player[]
+}
+
+export default function FinalReveal({ players }: FinalRevealProps) {
+  const sorted = [...players].sort((a, b) => b.score - a.score)
+
+  if (sorted.length === 0) return null
+
+  return (
+    <div style={{ padding: '2rem', textAlign: 'center' }}>
+      <h2>🎉 Finálne poradie</h2>
+      <p>Víťazom sa stáva:</p>
+      <h1
+        style={{ fontSize: '2.5rem', margin: '1rem 0', color: '#1e90ff' }}
+      >
+        🏆 {sorted[0].name}
+      </h1>
+
+      <ul style={{ listStyle: 'none', padding: 0 }}>
+        {sorted.map((player, idx) => (
+          <li key={player.id} style={{ fontSize: '1.2rem', marginBottom: '.5rem' }}>
+            {idx + 1}. {player.name} — {player.score} bodov
+          </li>
+        ))}
+      </ul>
+
+      <p style={{ marginTop: '2rem', fontStyle: 'italic' }}>
+        Ďakujeme za hranie!
+      </p>
+    </div>
+  )
+}
+

--- a/src/components/quiz/JoinGameWaitingRoom.tsx
+++ b/src/components/quiz/JoinGameWaitingRoom.tsx
@@ -1,0 +1,36 @@
+interface Player {
+  id: string
+  name: string
+}
+
+interface JoinGameWaitingRoomProps {
+  code: string
+  players: Player[]
+  onLock: () => void
+}
+
+export default function JoinGameWaitingRoom({ code, players, onLock }: JoinGameWaitingRoomProps) {
+  const joinUrl = `https://deeptalks.eu/sk/play/${code}`
+
+  return (
+    <div style={{ padding: '2rem', textAlign: 'center', color: '#000' }}>
+      <h2>🟢 Miestnosť aktívna</h2>
+      <p>Hráči sa môžu pripájať cez link:</p>
+      <p>
+        <a href={joinUrl}>{joinUrl}</a>
+      </p>
+
+      <h3>👥 Pripojení hráči ({players.length})</h3>
+      <ul style={{ listStyle: 'none', padding: 0 }}>
+        {players.map(p => (
+          <li key={p.id}>{p.name}</li>
+        ))}
+      </ul>
+
+      <button onClick={onLock} style={{ marginTop: '2rem' }}>
+        🔒 Zamknúť lobby a začať konfiguráciu
+      </button>
+    </div>
+  )
+}
+

--- a/src/components/quiz/Leaderboard.tsx
+++ b/src/components/quiz/Leaderboard.tsx
@@ -1,0 +1,30 @@
+interface Player {
+  id: string
+  name: string
+  score: number
+}
+
+interface LeaderboardProps {
+  players: Player[]
+}
+
+export default function Leaderboard({ players }: LeaderboardProps) {
+  const sorted = [...players].sort((a, b) => b.score - a.score)
+
+  return (
+    <div style={{ padding: '2rem', textAlign: 'center' }}>
+      <h2>🏁 Konečné poradie</h2>
+      <ol>
+        {sorted.map((player, idx) => (
+          <li key={player.id} style={{ fontSize: '1.2rem', marginBottom: '.5rem' }}>
+            <strong>
+              {idx + 1}. {player.name}
+            </strong>{' '}
+            — {player.score} bodov
+          </li>
+        ))}
+      </ol>
+    </div>
+  )
+}
+

--- a/src/components/quiz/QuestionCard.tsx
+++ b/src/components/quiz/QuestionCard.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 
 interface Question {
   text: string
-  options: string[]
+  options: [string, string, string, string]
 }
 
 interface QuestionCardProps {

--- a/src/components/quiz/QuestionCard.tsx
+++ b/src/components/quiz/QuestionCard.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react'
+
+interface Question {
+  text: string
+  options: string[]
+}
+
+interface QuestionCardProps {
+  question: Question
+  onAnswer: (choice: string) => void
+}
+
+export default function QuestionCard({ question, onAnswer }: QuestionCardProps) {
+  const [selected, setSelected] = useState<string | null>(null)
+
+  const handleClick = (label: string) => {
+    if (selected) return
+    setSelected(label)
+    onAnswer(label)
+  }
+
+  const renderButton = (label: string, text: string) => (
+    <button
+      key={label}
+      onClick={() => handleClick(label)}
+      style={{
+        backgroundColor: selected === label ? '#1e90ff' : '#f0f0f0',
+        color: selected === label ? '#fff' : '#000',
+        padding: '1rem',
+        margin: '0.5rem 0',
+        width: '100%',
+        fontSize: '1rem',
+        borderRadius: '8px',
+        cursor: selected ? 'default' : 'pointer',
+        border: '1px solid #ccc'
+      }}
+      disabled={!!selected}
+    >
+      {label}. {text}
+    </button>
+  )
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h3>{question.text}</h3>
+      <div>
+        {renderButton('A', question.options[0])}
+        {renderButton('B', question.options[1])}
+        {renderButton('C', question.options[2])}
+        {renderButton('D', question.options[3])}
+      </div>
+    </div>
+  )
+}
+

--- a/src/components/quiz/QuestionEvaluation.tsx
+++ b/src/components/quiz/QuestionEvaluation.tsx
@@ -1,0 +1,39 @@
+interface QuestionEvaluationProps {
+  playerAnswer: string | null
+  correctAnswer: string
+}
+
+export default function QuestionEvaluation({ playerAnswer, correctAnswer }: QuestionEvaluationProps) {
+  const isCorrect = playerAnswer === correctAnswer
+
+  return (
+    <div
+      style={{
+        padding: '2rem',
+        textAlign: 'center',
+        border: '1px solid #eee',
+        borderRadius: '12px',
+        maxWidth: '500px',
+        margin: '2rem auto'
+      }}
+    >
+      <h3>✅ Výsledok otázky</h3>
+      <p>
+        <strong>Správna odpoveď:</strong> {correctAnswer}
+      </p>
+      <p>
+        <strong>Tvoja odpoveď:</strong> {playerAnswer ?? '—'}
+      </p>
+      <p
+        style={{
+          fontSize: '1.5rem',
+          color: isCorrect ? 'green' : 'red',
+          marginTop: '1rem'
+        }}
+      >
+        {isCorrect ? 'Správne! ✅' : 'Nesprávne ❌'}
+      </p>
+    </div>
+  )
+}
+

--- a/src/components/quiz/QuestionTimer.tsx
+++ b/src/components/quiz/QuestionTimer.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+
+interface QuestionTimerProps {
+  duration: number
+  onTimeout: () => void
+}
+
+export default function QuestionTimer({ duration, onTimeout }: QuestionTimerProps) {
+  const [seconds, setSeconds] = useState(duration)
+
+  useEffect(() => {
+    if (seconds === 0) {
+      onTimeout()
+      return
+    }
+    const interval = setInterval(() => setSeconds(s => s - 1), 1000)
+    return () => clearInterval(interval)
+  }, [seconds, onTimeout])
+
+  return (
+    <div
+      style={{
+        fontSize: '2rem',
+        fontWeight: 'bold',
+        color: seconds <= 5 ? 'red' : 'black',
+        margin: '1rem auto'
+      }}
+    >
+      ⏱️ {seconds}s
+    </div>
+  )
+}
+

--- a/src/components/quiz/RoundSetupWizard.tsx
+++ b/src/components/quiz/RoundSetupWizard.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react'
+
+interface RoundConfig {
+  category: string
+  questionCount: number
+}
+
+interface RoundSetupWizardProps {
+  totalRounds: number
+  onFinish: (rounds: RoundConfig[]) => void
+}
+
+export default function RoundSetupWizard({ totalRounds, onFinish }: RoundSetupWizardProps) {
+  const [rounds, setRounds] = useState<RoundConfig[]>([])
+  const [currentIndex, setCurrentIndex] = useState(0)
+
+  const handleRoundSubmit = (category: string, questionCount: number) => {
+    const updated = [...rounds]
+    updated[currentIndex] = { category, questionCount }
+    setRounds(updated)
+
+    if (currentIndex + 1 < totalRounds) {
+      setCurrentIndex(currentIndex + 1)
+    } else {
+      onFinish(updated)
+    }
+  }
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h2>
+        Nastav kolo {currentIndex + 1} z {totalRounds}
+      </h2>
+      <RoundForm onSubmit={handleRoundSubmit} />
+    </div>
+  )
+}
+
+interface RoundFormProps {
+  onSubmit: (category: string, count: number) => void
+}
+
+function RoundForm({ onSubmit }: RoundFormProps) {
+  const [category, setCategory] = useState('')
+  const [count, setCount] = useState(3)
+
+  return (
+    <form
+      onSubmit={e => {
+        e.preventDefault()
+        onSubmit(category, count)
+      }}
+    >
+      <label>Kategória</label>
+      <select
+        required
+        value={category}
+        onChange={e => setCategory(e.target.value)}
+        style={{ display: 'block', marginBottom: '1rem' }}
+      >
+        <option value="">-- Vyber kategóriu --</option>
+        <option value="team">Tím</option>
+        <option value="fun">Zábava</option>
+      </select>
+
+      <label>Počet otázok</label>
+      <input
+        type="number"
+        min={1}
+        max={10}
+        value={count}
+        onChange={e => setCount(Number(e.target.value))}
+        style={{ display: 'block', marginBottom: '1rem' }}
+      />
+
+      <button type="submit">Nastaviť kolo</button>
+    </form>
+  )
+}
+


### PR DESCRIPTION
## Summary
- scaffold round setup wizard for configuring quiz rounds
- add reusable player lobby, question, timer, evaluation, and leaderboard components
- include final reveal component for end-game standings

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68b042854e18832786993b2b91c8ccc5