### PR TITLE
refactor admin panel phase rendering

### DIFF
--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -1,13 +1,15 @@
 'use client'
 import { useState } from 'react'
+
 import useGameState from '../hooks/useGameState'
 import useRealtimeGame from '../hooks/useRealtimeGame'
-import QuestionCard from './quiz/QuestionCard'
-import QuestionTimer from './quiz/QuestionTimer'
-import Leaderboard from './quiz/Leaderboard'
-import QuestionEvaluation from './quiz/QuestionEvaluation'
+
 import Button from './quiz/Button'
+import Leaderboard from './quiz/Leaderboard'
 import Loader from './Loader'
+import QuestionCard from './quiz/QuestionCard'
+import QuestionEvaluation from './quiz/QuestionEvaluation'
+import QuestionTimer from './quiz/QuestionTimer'
 
 interface AdminPanelProps {
   code: string
@@ -33,62 +35,93 @@ export default function AdminPanel({ code }: AdminPanelProps) {
 
   if (loading || !game) return <Loader />
 
-  return (
-    <div style={{ padding: '2rem' }}>
-      <h2>🛠️ Admin panel – hra {game.code}</h2>
+  const header = (
+    <>
+      <h2>🔧 Admin panel – hra {game.code}</h2>
       <p>
         Aktuálna fáza: <strong>{game.phase}</strong>
       </p>
-
-      {game.phase === 'lobby' && (
-        <div>
-          <p>Hráči sa pripájajú…</p>
-          <Button>🔒 Zamknúť lobby</Button>
-        </div>
-      )}
-
-      {game.phase === 'config' && (
-        <div>
-          <p>Nastav počet kôl a parametre</p>
-          <Button>✅ Uložiť konfiguráciu</Button>
-        </div>
-      )}
-
-      {game.phase === 'round_setup' && (
-        <div>
-          <p>Nastavenie kôl</p>
-          <Button>🎮 Ideme hrať</Button>
-        </div>
-      )}
-
-      {game.phase === 'playing' && (
-        <div>
-          {currentQuestion && (
-            <>
-              <QuestionCard question={currentQuestion} onAnswer={() => {}} />
-              {timerRunning && (
-                <QuestionTimer duration={30} onTimeout={() => setTimerRunning(false)} />
-              )}
-              {!timerRunning && (
-                <Button onClick={() => setTimerRunning(true)}>⏱️ Spustiť odpočet</Button>
-              )}
-              {timerRunning && (
-                <Button onClick={() => setTimerRunning(false)}>🔒 Uzamknúť odpovede</Button>
-              )}
-              {results && (
-                <QuestionEvaluation
-                  playerAnswer={results.playerAnswer}
-                  correctAnswer={results.correctAnswer}
-                  funFact={currentQuestion?.fun_fact}
-                />
-              )}
-              {results && <Button>➡️ Ďalšia otázka</Button>}
-            </>
-          )}
-        </div>
-      )}
-
-      {game.phase === 'final' && <Leaderboard players={game.players} />}
-    </div>
+    </>
   )
+
+  if (game.phase === 'lobby') {
+    return (
+      <div style={{ padding: '2rem' }}>
+        {header}
+        <p>Hráči sa pripájajú…</p>
+        <Button>🔒 Zamknúť lobby</Button>
+      </div>
+    )
+  }
+
+  if (game.phase === 'config') {
+    return (
+      <div style={{ padding: '2rem' }}>
+        {header}
+        <p>Nastav počet kôl a parametre</p>
+        <Button>✅ Uložiť konfiguráciu</Button>
+      </div>
+    )
+  }
+
+  if (game.phase === 'round_setup') {
+    return (
+      <div style={{ padding: '2rem' }}>
+        {header}
+        <p>Nastavenie kôl</p>
+        <Button>🎮 Ideme hrať</Button>
+      </div>
+    )
+  }
+
+  if (game.phase === 'playing') {
+    return (
+      <div style={{ padding: '2rem' }}>
+        {header}
+        {currentQuestion && (
+          <>
+            <QuestionCard question={currentQuestion} onAnswer={() => {}} />
+            {timerRunning && (
+              <QuestionTimer duration={30} onTimeout={() => setTimerRunning(false)} />
+            )}
+            {!timerRunning && (
+              <Button onClick={() => setTimerRunning(true)}>⏱️ Spustiť odpočet</Button>
+            )}
+            {timerRunning && (
+              <Button onClick={() => setTimerRunning(false)}>🔒 Uzamknúť odpovede</Button>
+            )}
+            {results && (
+              <QuestionEvaluation
+                playerAnswer={results.playerAnswer}
+                correctAnswer={results.correctAnswer}
+                funFact={currentQuestion?.fun_fact}
+              />
+            )}
+            {results && <Button>➡️ Ďalšia otázka</Button>}
+          </>
+        )}
+      </div>
+    )
+  }
+
+  if (game.phase === 'round_results') {
+    return (
+      <div style={{ padding: '2rem' }}>
+        {header}
+        <Leaderboard players={game.players} />
+        <Button>▶️ Pokračovať do ďalšieho kola</Button>
+      </div>
+    )
+  }
+
+  if (game.phase === 'final') {
+    return (
+      <div style={{ padding: '2rem' }}>
+        {header}
+        <Leaderboard players={game.players} />
+      </div>
+    )
+  }
+
+  return null
 }


### PR DESCRIPTION
## Summary
- refactor AdminPanel to return distinct screens for each game phase
- add round results handling and simplify header and imports

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b08dcbd6bc8327af3b5ca456f09409