### PR TITLE
Hide round controls until game start

### DIFF
--- a/src/app/[lang]/apps/herd-vote/page.tsx
+++ b/src/app/[lang]/apps/herd-vote/page.tsx
@@ -538,7 +538,7 @@ export default function HerdVoteAdminPage() {
             </div>
           )}
 
-          {rounds.length > 0 && (
+          {rounds.length > 0 && gameStatus === 'running' && (
             <div className="rounded-xl border p-4 space-y-3">
               <h2 className="font-semibold">Ovládanie kola</h2>
               <div className="flex gap-2 flex-wrap">


### PR DESCRIPTION
## Summary
- hide round control buttons until the game is running to avoid showing them during setup

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b091d2672c83279de33e5c0dc66d1d