### PR TITLE
fix: add dict prop for quiz client and update stripe API version

### DIFF
--- a/src/app/[lang]/apps/quiz/Client.tsx
+++ b/src/app/[lang]/apps/quiz/Client.tsx
@@ -22,9 +22,9 @@ function mapPhase(phase: string): GameStatus {
   return 'waiting'
 }
 
-type Props = { lang: string }
+type Props = { dict: any; lang: string }
 
-export default function QuizAdminClient({ lang }: Props) {
+export default function QuizAdminClient({ dict, lang }: Props) {
   const router = useRouter()
   const { user, loading, session } = useAuth()
   useEffect(() => {

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -2,9 +2,12 @@
 import { NextResponse } from 'next/server'
 import Stripe from 'stripe'
 
-const stripe = new Stripe("sk_test_51Ro77dAciFxB09IeiOU1ulLk0JlI4YY35WnkdqJ4XLLMb8x18tbqm2jb3Et90bv2MZrWazw1ej2KFox6JCBfqqcY00tT8svLfQ", {
-  apiVersion: '2025-06-30.basil',
-})
+const stripe = new Stripe(
+  "sk_test_51Ro77dAciFxB09IeiOU1ulLk0JlI4YY35WnkdqJ4XLLMb8x18tbqm2jb3Et90bv2MZrWazw1ej2KFox6JCBfqqcY00tT8svLfQ",
+  {
+    apiVersion: '2025-08-27.basil',
+  },
+)
 
 export async function POST() {
   try {


### PR DESCRIPTION
## Summary
- allow Quiz client to accept dictionary data
- update Stripe API version to satisfy type checks

## Testing
- `npm run typecheck`
- `npm test` *(fails: jest-environment-jsdom cannot be found; attempted install returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b2db2c50a48327bc7836fce5a0ad4c