### PR TITLE
feat: simplify moderator start by hiding config

### DIFF
--- a/src/app/[lang]/apps/quiz/Client.tsx
+++ b/src/app/[lang]/apps/quiz/Client.tsx
@@ -52,6 +52,7 @@ export default function QuizAdminClient({ dict, lang }: Props) {
 
   const [totalRounds, setTotalRounds] = useState<number>(0)
   const [roundInput, setRoundInput] = useState<number>(1)
+  const [showConfig, setShowConfig] = useState(false)
 
   const [rounds, setRounds] = useState<{ id: string; category: string }[]>([])
   const [players, setPlayers] = useState<Player[]>([])
@@ -59,6 +60,7 @@ export default function QuizAdminClient({ dict, lang }: Props) {
   const [leaderboard, setLeaderboard] = useState<Player[]>([])
 
   const hasCreated = useRef(false)
+  const autoConfigured = useRef(false)
 
   const authFetch = (url: string, options: RequestInit = {}) => {
     const headers = {
@@ -174,6 +176,14 @@ export default function QuizAdminClient({ dict, lang }: Props) {
     }
   }
 
+  useEffect(() => {
+    if (!autoConfigured.current && gameCode && categories.length > 0) {
+      autoConfigured.current = true
+      setTotalRounds(1)
+      addRound()
+    }
+  }, [gameCode, categories])
+
   const startGame = async () => {
     if (!gameCode) return
     const startResp = await authFetch(`/api/games/${gameCode}/rounds/start`, {
@@ -242,6 +252,20 @@ export default function QuizAdminClient({ dict, lang }: Props) {
     return `${origin}/${urlLang}/play/${gameCode}`
   }, [gameCode, lang])
 
+  const shareJoinUrl = async () => {
+    if (!joinUrl) return
+    try {
+      if (navigator.share) {
+        await navigator.share({ title: 'Herd Vote', url: joinUrl })
+      } else if (navigator.clipboard) {
+        await navigator.clipboard.writeText(joinUrl)
+        alert('Link skopírovaný do schránky')
+      }
+    } catch {
+      // ignoruj chyby zdieľania
+    }
+  }
+
   if (loading || !user) {
     return (
       <div className="mx-auto max-w-3xl p-6">
@@ -265,14 +289,38 @@ export default function QuizAdminClient({ dict, lang }: Props) {
 
       <div className="rounded-xl border p-4 space-y-4">
         <h2 className="font-semibold">Informácie o hre</h2>
-        <div className="space-y-1">
+        <div className="space-y-2">
           <div>
             <span className="font-medium">Kód hry:</span> {gameCode || '—'}
           </div>
           {joinUrl && (
-            <div className="break-all">
-              <span className="font-medium">Link pre hráčov:</span> {joinUrl}
-            </div>
+            <>
+              <div className="break-all">
+                <span className="font-medium">Link pre hráčov:</span>{' '}
+                <a
+                  href={joinUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 underline"
+                >
+                  {joinUrl}
+                </a>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={shareJoinUrl}
+                  className="px-2 py-1 text-sm rounded border"
+                >
+                  Zdieľať
+                </button>
+              </div>
+              <div className="flex justify-center pt-2">
+                <img
+                  src={`https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=${encodeURIComponent(joinUrl)}`}
+                  alt="QR kód"
+                />
+              </div>
+            </>
           )}
         </div>
       </div>
@@ -294,9 +342,30 @@ export default function QuizAdminClient({ dict, lang }: Props) {
         </div>
       )}
 
-      {gameStatus === 'waiting' && (
+      {gameStatus === 'waiting' && rounds.length > 0 && (
+        <div className="rounded-xl border p-4 space-y-2">
+          <button onClick={startGame} className="px-4 py-2 rounded bg-blue-600 text-white">
+            Začať hru
+          </button>
+          {!showConfig && (
+            <button
+              onClick={() => setShowConfig(true)}
+              className="px-4 py-2 rounded border"
+            >
+              Podrobné nastavenia
+            </button>
+          )}
+        </div>
+      )}
+
+      {gameStatus === 'waiting' && showConfig && (
         <div className="rounded-xl border p-4 space-y-4">
-          <h2 className="font-semibold">Konfigurácia hier</h2>
+          <div className="flex justify-between items-center">
+            <h2 className="font-semibold">Konfigurácia hier</h2>
+            <button onClick={() => setShowConfig(false)} className="text-sm underline">
+              Skryť
+            </button>
+          </div>
           <div className="space-y-2">
             <div>
               <label className="block text-sm mb-1">Celkový počet kôl</label>
@@ -456,12 +525,6 @@ export default function QuizAdminClient({ dict, lang }: Props) {
           ) : (
             <div className="space-y-2">
               <h2 className="font-semibold">Všetky kolá nastavené</h2>
-              <button
-                onClick={startGame}
-                className="px-4 py-2 rounded bg-blue-600 text-white"
-              >
-                Ideme hrať
-              </button>
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- hide quiz configuration behind optional toggle on moderator page
- auto-create a default round so moderators can start quickly
- restore QR code, clickable join link, and sharing on moderator page

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm run lint` *(fails: multiple existing ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b2df3d04308327a6c34dc90809c618