### PR TITLE
Return to lobby while round setup pending

### DIFF
--- a/src/app/api/games/[code]/route.ts
+++ b/src/app/api/games/[code]/route.ts
@@ -35,14 +35,11 @@ export async function GET(_req: NextRequest, context: any) {
     .select('idx', { count: 'exact', head: true })
     .eq('game_code', gameCode)
 
-  const phase =
-    g.phase === 'setup'
-      ? 'config'
-        : g.phase === 'running'
-        ? 'playing'
-          : g.phase === 'ended'
-          ? 'final'
-            : (g.phase as any) ?? 'lobby'
+  let phase: string = (g.phase as any) ?? 'lobby'
+  if (g.phase === 'setup') phase = 'config'
+  else if (g.phase === 'running') phase = 'playing'
+  else if (g.phase === 'ended') phase = 'final'
+  else if (g.phase === 'round_setup' && !g.lobby_locked) phase = 'lobby'
 
   return NextResponse.json({
       code: g.code,


### PR DESCRIPTION
## Summary
- Adjust game phase mapping so `round_setup` with open lobby returns `lobby`

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint` *(fails: multiple ESLint errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d1ff96a883278f7b1fc1f75e4122