### PR TITLE
fix: close div tag in quiz client

### DIFF
--- a/src/app/[lang]/apps/quiz/Client.tsx
+++ b/src/app/[lang]/apps/quiz/Client.tsx
@@ -273,6 +273,7 @@ export default function QuizAdminClient({ lang }: Props) {
     <div className="mx-auto max-w-3xl p-6 space-y-6">
       <div className="flex justify-end text-sm text-muted-foreground gap-2 items-center">
         <UserCircle className="h-5 w-5" />
+      </div>
 
       <div className="rounded-xl border p-4 space-y-4">
         <h2 className="font-semibold">Informácie o hre</h2>


### PR DESCRIPTION
## Summary
- close missing div in quiz moderator page

## Testing
- `npm run typecheck`
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint` *(fails: multiple lint errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e89dcd908327b793565cd14ca7cb