### PR TITLE
Log detailed error from herd questions RPC

### DIFF
--- a/src/app/api/games/[code]/rounds/start/route.ts
+++ b/src/app/api/games/[code]/rounds/start/route.ts
@@ -41,7 +41,8 @@ export async function POST(req: NextRequest, context: any) {
   })
 
   if (qErr) {
-    return NextResponse.json({ error: 'NOT_ENOUGH_QUESTIONS' }, { status: 400 })
+    console.error('random_herd_questions error:', qErr.message)
+    return NextResponse.json({ error: qErr.message }, { status: 400 })
   }
   const ids = asArray<{ id: string }>(qs).map(q => q.id)
   if (ids.length < round.count) {

--- a/src/app/api/games/[code]/rounds/start/route.ts
+++ b/src/app/api/games/[code]/rounds/start/route.ts
@@ -41,7 +41,7 @@ export async function POST(req: NextRequest, context: any) {
   })
 
   if (qErr) {
-    console.error('random_herd_questions error:', qErr.message)
+    console.error('random_herd_questions RPC failed:', qErr.message, qErr)
     return NextResponse.json({ error: qErr.message }, { status: 400 })
   }
   const ids = asArray<{ id: string }>(qs).map(q => q.id)


### PR DESCRIPTION
## Summary
- log `random_herd_questions` RPC failures for easier debugging

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm run lint` *(fails: multiple ESLint errors)*
- `npm run typecheck` *(fails: TypeScript errors in quiz Client.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b4132f0b5c832794120b5639898ac3