### PR TITLE
fix: use question table for round setup

### DIFF
--- a/src/app/api/games/[code]/rounds/route.ts
+++ b/src/app/api/games/[code]/rounds/route.ts
@@ -68,9 +68,10 @@ export async function POST(req: NextRequest, context: any) {
     }
 
     const { data: qdata, error: qErr } = await supabase
-      .from('herd_questions')
+      .from('questions')
       .select('id')
       .eq('category_id', catRow.id)
+      .eq('admin_status', 3)
 
     if (qErr) {
       return NextResponse.json({ error: qErr.message }, { status: 400 })

--- a/supabase/migrations/20250806210000_random_herd_questions.sql
+++ b/supabase/migrations/20250806210000_random_herd_questions.sql
@@ -1,9 +1,10 @@
 create or replace function random_herd_questions(cat uuid, n int)
-returns table(id uuid)
+returns table(id bigint)
 language sql stable as $$
   select q.id
-  from herd_questions q
+  from questions q
   where q.category_id = cat
+    and q.admin_status = 3
   order by random()
   limit n
 $$;


### PR DESCRIPTION
## Summary
- ensure round setup pulls from `questions` table and only approved items
- align random question RPC with questions table

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*
- `npm install --save-dev jest-environment-jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b42175092c83278e6712504393839f