### PR TITLE
fix: validate round questions and remove duplicate QR

### DIFF
--- a/src/app/[lang]/apps/quiz/Client.tsx
+++ b/src/app/[lang]/apps/quiz/Client.tsx
@@ -323,47 +323,7 @@ export default function QuizAdminClient({ lang }: Props) {
           </button>
         )}
 
-        {/* Link + QR len kým je lobby otvorené */}
-        {gameCode && gameStatus === 'waiting' && (
-          <div className="space-y-2">
-            <div>
-              <b>Kód hry:</b> {gameCode}
-            </div>
-            <div>
-              <b>Link pre hráčov:</b>{' '}
-              <a className="text-blue-600 underline" href={joinUrl} target="_blank" rel="noopener noreferrer">
-                {joinUrl}
-              </a>
-            </div>
-            <div className="pt-2">
-              <img
-                src={`https://api.qrserver.com/v1/create-qr-code/?size=220x220&data=${encodeURIComponent(joinUrl)}`}
-                alt="QR pre pripojenie hráčov"
-                className="border rounded"
-              />
-            </div>
-            <div className="flex gap-2">
-              <button onClick={() => navigator.clipboard.writeText(joinUrl)} className="px-3 py-2 rounded border text-sm">
-                Kopírovať link
-              </button>
-              <button
-                onClick={async () => {
-                  if ((navigator as any).share) {
-                    try {
-                      await (navigator as any).share({ title: 'Herd Vote', url: joinUrl })
-                    } catch {}
-                  } else {
-                    alert('Zdieľanie nie je podporované – použite Kopírovať link.')
-                  }
-                }}
-                className="px-3 py-2 rounded bg-black text-white text-sm"
-              >
-                Zdieľať
-              </button>
-            </div>
-
-          </div>
-        )}
+        {/* QR a link pre pripojenie sú zobrazené vyššie v sekcii Informácie o hre */}
 
       </div>
 

--- a/src/app/api/games/[code]/rounds/config/route.ts
+++ b/src/app/api/games/[code]/rounds/config/route.ts
@@ -21,6 +21,21 @@ export async function POST(req: NextRequest, context: any) {
 
   const s = supabaseServer(session.access_token) as any // "as any" obíde TS typy generované zo Supabase
 
+  // over dostupný počet otázok v danej kategórii podľa rovnakých filtrov ako RPC random_herd_questions
+  const { count: available } = await s
+    .from('herd_questions')
+    .select('id', { count: 'exact', head: true })
+    .eq('category_id', categoryId)
+    .eq('classic', true)
+    .or('locale.is.null,locale.eq.sk')
+
+  if ((available ?? 0) < Number(questions)) {
+    return NextResponse.json(
+      { error: 'NOT_ENOUGH_QUESTIONS', available },
+      { status: 400 }
+    )
+  }
+
   // uloženie/aktualizácia kola (idempotentne podľa game_code + idx)
     const { data: saved, error } = await s
       .from('herd_rounds')

--- a/supabase/migrations/20250806230000_herd_rounds_unique_idx.sql
+++ b/supabase/migrations/20250806230000_herd_rounds_unique_idx.sql
@@ -1,0 +1,5 @@
+-- Add unique index for herd_rounds and cleanup duplicates
+DELETE FROM herd_rounds a USING herd_rounds b
+WHERE a.id < b.id AND a.game_code = b.game_code AND a.idx = b.idx;
+
+CREATE UNIQUE INDEX IF NOT EXISTS herd_rounds_game_idx_uq ON herd_rounds (game_code, idx);


### PR DESCRIPTION
## Summary
- check available questions when configuring rounds to surface NOT_ENOUGH_QUESTIONS early
- remove duplicate QR code from quiz lobby
- add migration enforcing unique herd round index

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm install jest-environment-jsdom -D` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b42857d464832782822d07726fc9cd