### PR TITLE
Remove classic question filter from round configuration

### DIFF
--- a/src/app/api/games/[code]/rounds/config/route.ts
+++ b/src/app/api/games/[code]/rounds/config/route.ts
@@ -26,7 +26,6 @@ export async function POST(req: NextRequest, context: any) {
     .from('herd_questions')
     .select('id', { count: 'exact', head: true })
     .eq('category_id', categoryId)
-    .eq('classic', true)
     .or('locale.is.null,locale.eq.sk')
 
   if ((available ?? 0) < Number(questions)) {


### PR DESCRIPTION
## Summary
- Do not restrict available round questions by `classic` flag when counting

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm install -D jest-environment-jsdom` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b134af0c832791d767860e2caf52