### PR TITLE
Handle locked lobby as configuration phase

### DIFF
--- a/src/app/[lang]/apps/quiz/Client.tsx
+++ b/src/app/[lang]/apps/quiz/Client.tsx
@@ -15,9 +15,9 @@ type GameStatus = 'waiting' | 'configuring' | 'running' | 'finished'
 function mapPhase(phase: string): GameStatus {
   const p = phase.toLowerCase().trim()
   if (p === 'lobby') return 'waiting'
-  if (p === 'setup' || p === 'config' || p === 'round_setup' || p === 'ready')
+  if (p === 'setup' || p === 'config' || p === 'round_setup' || p === 'ready' || p === 'locked')
     return 'configuring'
-  if (p === 'running' || p === 'playing' || p === 'locked' || p === 'reveal') return 'running'
+  if (p === 'running' || p === 'playing' || p === 'reveal') return 'running'
   if (p === 'ended' || p === 'final') return 'finished'
 
   return 'waiting'

--- a/src/app/api/games/[code]/lock-lobby/route.ts
+++ b/src/app/api/games/[code]/lock-lobby/route.ts
@@ -16,12 +16,12 @@ export async function POST(_req: NextRequest, context: any) {
 
   const { error } = await s
     .from('herd_games')
-    .update({ lobby_locked: true, phase: 'locked' })
+    .update({ lobby_locked: true, phase: 'setup' })
     .eq('code', gameCode)
     .eq('owner_id', session.user.id)
 
   if (error) return NextResponse.json({ error: error.message }, { status: 400 })
 
-  return NextResponse.json({ success: true, phase: 'locked' })
+  return NextResponse.json({ success: true, phase: 'setup' })
 
 }


### PR DESCRIPTION
## Summary
- Map `locked` game phase to the `configuring` state on the client
- Set server lock-lobby endpoint to mark phase as `setup`

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint` *(fails: This assertion is unnecessary since it does not change the type of the expression)*

------
https://chatgpt.com/codex/tasks/task_e_68b605d8580c8327ae83ded09875ff5b