### PR TITLE
Add theme toggle to quiz admin page

### DIFF
--- a/src/app/[lang]/apps/quiz/page.tsx
+++ b/src/app/[lang]/apps/quiz/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation'
 import { normalizeUrlLocale } from '@/lib/i18n-routing'
 import { type Locale, SUPPORTED_LOCALES } from '@/i18n/config'
 import QuizAdminClient from './Client'
+import SiteHeader from '@/components/SiteHeader'
 
 export const dynamic = 'force-dynamic'
 
@@ -12,6 +13,11 @@ export default async function QuizPage({ params }: P) {
   const lang = normalizeUrlLocale(raw)
   if (!SUPPORTED_LOCALES.includes(lang as Locale)) notFound()
 
-  return <QuizAdminClient lang={lang} />
+  return (
+    <>
+      <SiteHeader lang={lang} />
+      <QuizAdminClient lang={lang} />
+    </>
+  )
 
 }

--- a/src/components/quiz/__tests__/ThemeToggleLobby.test.tsx
+++ b/src/components/quiz/__tests__/ThemeToggleLobby.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { describe, it, expect, jest, beforeAll } from '@jest/globals'
+import ThemeToggle from '@/components/ThemeToggle'
+import JoinGameWaitingRoom from '@/components/quiz/JoinGameWaitingRoom'
+
+function TestPage() {
+  const [locked, setLocked] = useState(false)
+  return (
+    <>
+      <div data-testid="theme-wrapper">
+        <ThemeToggle />
+      </div>
+      {locked ? (
+        <div data-testid="locked">locked</div>
+      ) : (
+        <JoinGameWaitingRoom code="abc" players={[]} onLock={() => setLocked(true)} />
+      )}
+    </>
+  )
+}
+
+describe('ThemeToggle', () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    })
+  })
+
+  it('keeps dark theme after lobby lock', async () => {
+    const user = userEvent.setup()
+    render(<TestPage />)
+
+    const toggleBtn = within(screen.getByTestId('theme-wrapper')).getByRole('button')
+    await user.click(toggleBtn)
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+
+    await user.click(screen.getByRole('button', { name: /zamknúť lobby/i }))
+    expect(screen.getByTestId('locked')).toBeInTheDocument()
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- show global SiteHeader with ThemeToggle on quiz admin page
- add Jest test verifying dark theme persists after locking the lobby

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b605e08b008327974cf1e250a89596