### PR TITLE
Handle locked lobby as configuration phase

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@types/jest": "^29.5.5",
     "cypress": "^13.7.3",
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "ts-jest": "^29.1.1"
   }
 }

--- a/src/app/[lang]/apps/quiz/Client.tsx
+++ b/src/app/[lang]/apps/quiz/Client.tsx
@@ -17,7 +17,7 @@ function mapPhase(phase: string): GameStatus {
   if (p === 'lobby') return 'waiting'
   if (p === 'setup' || p === 'config' || p === 'round_setup' || p === 'ready')
     return 'configuring'
-  if (p === 'running' || p === 'playing' || p === 'locked' || p === 'reveal') return 'running'
+  if (p === 'running' || p === 'playing' || p === 'reveal') return 'running'
   if (p === 'ended' || p === 'final') return 'finished'
 
   return 'waiting'

--- a/src/app/api/games/[code]/lock-lobby/route.ts
+++ b/src/app/api/games/[code]/lock-lobby/route.ts
@@ -16,12 +16,12 @@ export async function POST(_req: NextRequest, context: any) {
 
   const { error } = await s
     .from('herd_games')
-    .update({ lobby_locked: true, phase: 'locked' })
+    .update({ lobby_locked: true, phase: 'round_setup' })
     .eq('code', gameCode)
     .eq('owner_id', session.user.id)
 
   if (error) return NextResponse.json({ error: error.message }, { status: 400 })
 
-  return NextResponse.json({ success: true, phase: 'locked' })
+  return NextResponse.json({ success: true, phase: 'round_setup' })
 
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "baseUrl": ".",
     "paths": { "@/*": ["./src/*"] },
 
-    "types": ["node", "next", "jest"],
+    "types": ["node", "next", "jest", "@testing-library/jest-dom"],
 
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- Map round_setup phase to configuration and simplify client-side phase mapping
- Mark lobby lock API calls with round_setup so rounds can be configured
- Add jest-dom typings and environment to support DOM-specific test matchers

## Testing
- `npm run typecheck` *(fails: Error: This assertion is unnecessary since it does not change the type of the expression)*
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm run lint` *(fails: Error: This assertion is unnecessary since it does not change the type of the expression)*

------
https://chatgpt.com/codex/tasks/task_e_68b605d8580c8327ae83ded09875ff5b