### PR TITLE
Add moderator word preview with sample fallback data

### DIFF
--- a/src/components/hadacka/SettingsPanel.tsx
+++ b/src/components/hadacka/SettingsPanel.tsx
@@ -16,7 +16,7 @@ interface SettingsPanelProps {
 }
 
 export function SettingsPanel({ onStartGame }: SettingsPanelProps) {
-  const { settings, updateSettings } = useGameStore()
+  const { settings, updateSettings, gameState } = useGameStore()
   const [availableCategories, setAvailableCategories] = useState<Array<{ code: string; name: string }>>([])
 
   useEffect(() => {
@@ -177,6 +177,30 @@ export function SettingsPanel({ onStartGame }: SettingsPanelProps) {
               Vybraté: {settings.categories.length} kategórií
             </div>
           </div>
+        </CardContent>
+      </Card>
+
+      {/* Word Preview */}
+      <Card className="card-elegant lg:col-span-3">
+        <CardHeader>
+          <CardTitle>🔍 Náhľad slov</CardTitle>
+          <CardDescription>Slová pripravené pre hru (max 20)</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {gameState.wordPool.length > 0 ? (
+            <ul className="list-disc pl-4 space-y-1 max-h-48 overflow-y-auto">
+              {gameState.wordPool.slice(0, 20).map((w) => (
+                <li key={w.id}>
+                  {w.word}
+                  {w.categoryName && (
+                    <span className="text-muted-foreground"> ({w.categoryName})</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-muted-foreground">Žiadne slová nenačítané</p>
+          )}
         </CardContent>
       </Card>
 

--- a/src/data/hadacka/sampleCategories.ts
+++ b/src/data/hadacka/sampleCategories.ts
@@ -1,0 +1,7 @@
+export const sampleCategories = [
+  { code: 'zvierata', name: 'Zvieratá' },
+  { code: 'jedlo', name: 'Jedlo' },
+  { code: 'technika', name: 'Technika' },
+  { code: 'doprava', name: 'Doprava' },
+  { code: 'sport', name: 'Šport' },
+]

--- a/src/data/hadacka/sampleWords.ts
+++ b/src/data/hadacka/sampleWords.ts
@@ -1,0 +1,45 @@
+import type { WordVM } from '@/types/hadacka'
+
+export const sampleWords: WordVM[] = [
+  {
+    id: '1',
+    word: 'pes',
+    categoryCode: 'zvierata',
+    categoryName: 'Zvieratá',
+    difficultyLevel: 1,
+    modeCode: 'opis-tabu',
+  },
+  {
+    id: '2',
+    word: 'pizza',
+    categoryCode: 'jedlo',
+    categoryName: 'Jedlo',
+    difficultyLevel: 1,
+    modeCode: 'opis-tabu',
+  },
+  {
+    id: '3',
+    word: 'telefón',
+    categoryCode: 'technika',
+    categoryName: 'Technika',
+    difficultyLevel: 1,
+    modeCode: 'opis-tabu',
+  },
+  {
+    id: '4',
+    word: 'auto',
+    categoryCode: 'doprava',
+    categoryName: 'Doprava',
+    difficultyLevel: 1,
+    modeCode: 'opis-tabu',
+  },
+  {
+    id: '5',
+    word: 'futbal',
+    categoryCode: 'sport',
+    categoryName: 'Šport',
+    difficultyLevel: 1,
+    modeCode: 'opis-tabu',
+  },
+]
+

--- a/src/lib/services/wordService.ts
+++ b/src/lib/services/wordService.ts
@@ -1,37 +1,56 @@
 import { supabase } from '@/lib/supabase/client'
 import { asArray } from '@/lib/supabase/safe'
 import type { WordVM } from '@/types/hadacka'
+import { sampleWords } from '@/data/hadacka/sampleWords'
+import { sampleCategories } from '@/data/hadacka/sampleCategories'
 
 export class WordService {
   static async getWordsByCategories(categories: string[]): Promise<WordVM[]> {
-    const query = supabase
-      .from('had_words')
-      .select('id, word, category_code, difficulty_level, mode_code, category:had_categories(name)')
-    if (categories && categories.length > 0) {
-      query.in('category_code', categories)
-    }
+    try {
+        const query = supabase
+          .from('had_words')
+          .select('id, word, category_code, difficulty_level, mode_code, category:had_categories(name)')
+        if (categories.length > 0) {
+          query.in('category_code', categories)
+        }
       const { data, error } = await query
       if (error) throw error
-      return asArray(data).map(w => {
-        const catName = (w as any).category?.name as string | undefined
-        return {
-          id: String(w.id),
-          word: w.word as string,
-          categoryCode: w.category_code as string,
-          ...(catName ? { categoryName: catName } : {}),
-          difficultyLevel: w.difficulty_level as number,
-          modeCode: w.mode_code as string,
-        }
-      })
+        const words = asArray(data).map(w => {
+          const catName = (w as { category?: { name?: string } }).category?.name
+          return {
+            id: String(w.id),
+            word: w.word as string,
+            categoryCode: w.category_code as string,
+            ...(typeof catName === 'string' ? { categoryName: catName } : {}),
+            difficultyLevel: w.difficulty_level as number,
+            modeCode: w.mode_code as string,
+          }
+        })
+      if (words.length > 0) return words
+      // fallthrough to sample data if no words returned
+      throw new Error('No words returned from supabase')
+    } catch (error) {
+      console.warn('Using sample words due to fetch error:', error)
+      return sampleWords.filter(w =>
+        categories.length === 0 || categories.includes(w.categoryCode)
+      )
     }
+  }
 
   static async getAvailableCategories(): Promise<Array<{ code: string; name: string }>> {
+    try {
       const { data, error } = await supabase
         .from('had_categories')
         .select('code,name')
         .order('name')
       if (error) throw error
-      return asArray(data).map(c => ({ code: c.code as string, name: c.name as string }))
+      const categories = asArray(data).map(c => ({ code: c.code as string, name: c.name as string }))
+      if (categories.length > 0) return categories
+      throw new Error('No categories returned from supabase')
+    } catch (error) {
+      console.warn('Using sample categories due to fetch error:', error)
+      return sampleCategories
+    }
   }
 
   static async getPacks(): Promise<Array<{ code: string; name: string; isPremium: boolean }>> {


### PR DESCRIPTION
## Summary
- Add sample word and category data for Hadacka game
- Fallback to sample data when Supabase fetch fails
- Show loaded word preview on moderator settings page

## Testing
- `npm test` *(fails: jest-environment-jsdom missing)*
- `npm run lint` *(fails: multiple ESLint errors across repo)*

------
https://chatgpt.com/codex/tasks/task_e_68b607518e708327985fe85cb75e2e27