### PR TITLE
feat: add beta quiz to apps list

### DIFF
--- a/src/app/[lang]/apps/cards2/page.tsx
+++ b/src/app/[lang]/apps/cards2/page.tsx
@@ -1,0 +1,20 @@
+import { notFound } from 'next/navigation'
+import { normalizeUrlLocale } from '@/lib/i18n-routing'
+import { type Locale, SUPPORTED_LOCALES } from '@/i18n/config'
+
+export const dynamic = 'force-dynamic'
+
+type P = { params: Promise<{ lang: string }> }
+
+export default async function Cards2Page({ params }: P) {
+  const { lang: raw } = await params
+  const lang = normalizeUrlLocale(raw)
+  if (!SUPPORTED_LOCALES.includes(lang as Locale)) notFound()
+  return (
+    <iframe
+      src="/apps/cards2"
+      title="Conversation cards beta"
+      className="w-full h-screen border-0"
+    />
+  )
+}

--- a/src/app/[lang]/apps/page.tsx
+++ b/src/app/[lang]/apps/page.tsx
@@ -23,7 +23,7 @@ export default async function AppsPage({ params }: P) {
   const apps = dict.apps
   const games = apps.games
   const categories = [
-    { key: 'quizzes', slugs: ['quiz'], image: quizGameImage },
+    { key: 'quizzes', slugs: ['quiz', 'quiz-master'], image: quizGameImage },
     { key: 'cards', slugs: ['spoznajme-sa'], image: spoznajmeSaImage },
     { key: 'puzzles', slugs: ['hadacka'], image: hadackaImage },
     { key: 'surveys', slugs: ['couplesync'], image: couplesyncImage },
@@ -31,6 +31,7 @@ export default async function AppsPage({ params }: P) {
 
   const imageMap: Record<string, any> = {
     'quiz': quizGameImage,
+    'quiz-master': quizGameImage,
     'spoznajme-sa': spoznajmeSaImage,
     'hadacka': hadackaImage,
     'couplesync': couplesyncImage,

--- a/src/app/[lang]/apps/page.tsx
+++ b/src/app/[lang]/apps/page.tsx
@@ -24,7 +24,7 @@ export default async function AppsPage({ params }: P) {
   const games = apps.games
   const categories = [
     { key: 'quizzes', slugs: ['quiz', 'quiz-master'], image: quizGameImage },
-    { key: 'cards', slugs: ['spoznajme-sa'], image: spoznajmeSaImage },
+    { key: 'cards', slugs: ['spoznajme-sa', 'cards2'], image: spoznajmeSaImage },
     { key: 'puzzles', slugs: ['hadacka'], image: hadackaImage },
     { key: 'surveys', slugs: ['couplesync'], image: couplesyncImage },
   ]
@@ -33,6 +33,7 @@ export default async function AppsPage({ params }: P) {
     'quiz': quizGameImage,
     'quiz-master': quizGameImage,
     'spoznajme-sa': spoznajmeSaImage,
+    'cards2': spoznajmeSaImage,
     'hadacka': hadackaImage,
     'couplesync': couplesyncImage,
   }

--- a/src/app/[lang]/apps/quiz-master/page.tsx
+++ b/src/app/[lang]/apps/quiz-master/page.tsx
@@ -1,0 +1,21 @@
+import { notFound } from 'next/navigation'
+import { normalizeUrlLocale } from '@/lib/i18n-routing'
+import { type Locale, SUPPORTED_LOCALES } from '@/i18n/config'
+
+// Temporary wrapper to expose the new quiz (beta) build
+export const dynamic = 'force-dynamic'
+
+type P = { params: Promise<{ lang: string }> }
+
+export default async function QuizMasterPage({ params }: P) {
+  const { lang: raw } = await params
+  const lang = normalizeUrlLocale(raw)
+  if (!SUPPORTED_LOCALES.includes(lang as Locale)) notFound()
+  return (
+    <iframe
+      src="/apps/quiz"
+      title="Quiz Master"
+      className="w-full h-screen border-0"
+    />
+  )
+}

--- a/src/i18n/dictionaries/en.json
+++ b/src/i18n/dictionaries/en.json
@@ -94,6 +94,17 @@
           "Share your answers"
         ]
       },
+      "cards2": {
+        "name": "Conversation cards (beta)",
+        "description": "Conversations that bring you closer. Cards full of questions to get to know partner, friends or family.",
+        "cta": "Pick cards",
+        "link": "/apps/cards2",
+        "manual": [
+          "Choose a deck",
+          "Draw a card",
+          "Share your answers"
+        ]
+      },
       "hadacka": {
         "name": "Riddle – Guess the answer",
         "description": "A fun game for quick thinking. Can you guess what your partner has in mind?",

--- a/src/i18n/dictionaries/en.json
+++ b/src/i18n/dictionaries/en.json
@@ -72,6 +72,17 @@
           "Compare who matches best"
         ]
       },
+      "quiz-master": {
+        "name": "Quiz – team quiz (beta)",
+        "description": "Test how well you know each other. Fun questions from easy to unexpected – who knows you best?",
+        "cta": "Start quiz",
+        "link": "/apps/quiz-master",
+        "manual": [
+          "Create or join a game",
+          "Answer the questions",
+          "Compare who matches best"
+        ]
+      },
       "spoznajme-sa": {
         "name": "Conversation cards",
         "description": "Conversations that bring you closer. Cards full of questions to get to know partner, friends or family.",
@@ -122,7 +133,11 @@
           "Results you can talk about"
         ],
         "barriersTitle": "What usually blocks intimacy",
-        "barriersCards": ["Stress and fatigue", "Desire discrepancy", "Postpartum / health periods"],
+        "barriersCards": [
+          "Stress and fatigue",
+          "Desire discrepancy",
+          "Postpartum / health periods"
+        ],
         "howTitle": "How it works",
         "howSteps": [
           "Create a private room",

--- a/src/i18n/dictionaries/sk.json
+++ b/src/i18n/dictionaries/sk.json
@@ -96,6 +96,17 @@
           "Zdieľajte odpovede"
         ]
       },
+      "cards2": {
+        "name": "Konverzačné kartičky (beta)",
+        "description": "Rozhovory, ktoré vás zblížia. Kartičky plné otázok na hlbšie spoznanie partnera, kamarátov, rodiny.",
+        "cta": "Vybrať kartičky",
+        "link": "/apps/cards2",
+        "manual": [
+          "Vyberte balíček",
+          "Potiahnite kartičku",
+          "Zdieľajte odpovede"
+        ]
+      },
       "hadacka": {
         "name": "Hádanka – Hádaj odpoveď",
         "description": "Zábavná hra na rýchle myslenie. Dokážete uhádnuť, čo má partner na mysli?",

--- a/src/i18n/dictionaries/sk.json
+++ b/src/i18n/dictionaries/sk.json
@@ -74,6 +74,17 @@
           "Porovnajte, kto sa pozná najlepšie"
         ]
       },
+      "quiz-master": {
+        "name": "Quiz – tímový kvíz (beta)",
+        "description": "Otestujte, ako dobre sa poznáte. Zábavné otázky od ľahkých až po nečakané – kto vás pozná lepšie?",
+        "cta": "Začať kvíz",
+        "link": "/apps/quiz-master",
+        "manual": [
+          "Vytvorte alebo sa pripojte k hre",
+          "Odpovedajte na otázky",
+          "Porovnajte, kto sa pozná najlepšie"
+        ]
+      },
       "spoznajme-sa": {
         "name": "Konverzačné kartičky",
         "description": "Rozhovory, ktoré vás zblížia. Kartičky plné otázok na hlbšie spoznanie partnera, kamarátov, rodiny.",
@@ -124,7 +135,11 @@
           "Výsledky, o ktorých sa dá rozprávať"
         ],
         "barriersTitle": "Čo typicky brzdí intimitu",
-        "barriersCards": ["Stres a únava", "Rozdiel v túžbe", "Obdobia po pôrode / zdravie"],
+        "barriersCards": [
+          "Stres a únava",
+          "Rozdiel v túžbe",
+          "Obdobia po pôrode / zdravie"
+        ],
         "howTitle": "Ako to funguje",
         "howSteps": [
           "Vytvoríte súkromnú miestnosť",


### PR DESCRIPTION
## Summary
- show new Quiz Master beta alongside existing quiz in apps listing
- add translations for quiz master (beta) in English and Slovak
- expose beta quiz through temporary iframe page

## Testing
- `npm test`
- `npm run lint` *(fails: This assertion is unnecessary since it does not change the type of the expression, Unexpected any, Unexpected nullable string value, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c76aed6c832788e1f927796ee864