### PR TITLE
Add marketing pages for pricing and free resources

### DIFF
--- a/src/app/(marketing)/free/page.tsx
+++ b/src/app/(marketing)/free/page.tsx
@@ -1,0 +1,76 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Free Resources | DeepTalks',
+  description:
+    'Start meaningful conversations today with our curated free question packs, guides, and facilitation tools.',
+  alternates: {
+    canonical: 'https://deeptalks.eu/free',
+  },
+}
+
+const resources = [
+  {
+    title: 'Weekly Conversation Prompt',
+    description:
+      'A thoughtful question in your inbox every Monday to spark reflection and connection.',
+    action: { label: 'Subscribe for free', href: '/newsletter' },
+  },
+  {
+    title: 'Starter Question Pack',
+    description:
+      'Ten essential prompts to help you and your loved ones ease into deeper conversations.',
+    action: { label: 'Download PDF', href: '/downloads/starter-pack.pdf' },
+  },
+  {
+    title: 'Mini Facilitation Guide',
+    description:
+      'Step-by-step tips for hosting a 30-minute DeepTalks circle with friends or colleagues.',
+    action: { label: 'Read online', href: '/blog/facilitation-guide' },
+  },
+]
+
+export default function Page() {
+  return (
+    <main className="mx-auto max-w-4xl px-4 py-12 space-y-12">
+      <header className="space-y-4 text-center">
+        <p className="text-sm font-semibold uppercase tracking-wide text-primary">Free resources</p>
+        <h1 className="text-4xl font-bold">Everything you need to get started</h1>
+        <p className="mx-auto max-w-2xl text-muted-foreground">
+          DeepTalks is about creating small moments of connection every day. These free resources are designed to
+          help you build momentum and bring the magic of structured conversations into your home, classroom, or
+          community.
+        </p>
+      </header>
+
+      <section className="grid gap-6 md:grid-cols-3">
+        {resources.map((resource) => (
+          <article key={resource.title} className="flex flex-col rounded-2xl border border-border bg-card p-6 shadow-sm">
+            <h2 className="text-xl font-semibold">{resource.title}</h2>
+            <p className="mt-3 flex-1 text-sm text-muted-foreground">{resource.description}</p>
+            <a
+              href={resource.action.href}
+              className="mt-6 inline-flex items-center font-medium text-primary underline-offset-4 hover:underline"
+            >
+              {resource.action.label}
+            </a>
+          </article>
+        ))}
+      </section>
+
+      <section className="rounded-2xl border border-dashed border-primary/40 bg-primary/5 p-8 text-center">
+        <h2 className="text-2xl font-semibold">Bring DeepTalks to your group</h2>
+        <p className="mt-2 text-muted-foreground">
+          Ready to go deeper? Explore our paid plans for access to unlimited question packs, facilitation templates,
+          and advanced analytics.
+        </p>
+        <a
+          href="/pricing"
+          className="mt-6 inline-flex items-center justify-center rounded-full bg-primary px-6 py-3 text-sm font-medium text-primary-foreground transition hover:bg-primary/90"
+        >
+          View pricing
+        </a>
+      </section>
+    </main>
+  )
+}

--- a/src/app/(marketing)/pricing/page.tsx
+++ b/src/app/(marketing)/pricing/page.tsx
@@ -1,0 +1,86 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Pricing | DeepTalks',
+  description:
+    'Choose the DeepTalks plan that fits your group. Explore flexible options for families, couples, and facilitators.',
+  alternates: {
+    canonical: 'https://deeptalks.eu/pricing',
+  },
+}
+
+const tiers = [
+  {
+    name: 'Starter',
+    price: 'Free',
+    description:
+      'Perfect for curious pairs who want to try a guided conversation before committing.',
+    features: ['Access to rotating free question packs', 'Weekly conversation prompts', 'Mobile web experience'],
+  },
+  {
+    name: 'Family',
+    price: '€9 / month',
+    description:
+      'Designed for families and couples who want deeper, more frequent check-ins.',
+    features: ['Unlimited question packs', 'Shared conversation journal', 'Printable conversation guides'],
+  },
+  {
+    name: 'Facilitator',
+    price: '€29 / month',
+    description:
+      'For coaches, educators, and community leaders who host group sessions.',
+    features: ['All Family features', 'Session planning templates', 'Priority support and onboarding'],
+  },
+]
+
+export default function Page() {
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-12 space-y-10">
+      <header className="space-y-4 text-center">
+        <p className="text-sm font-semibold uppercase tracking-wide text-primary">Pricing</p>
+        <h1 className="text-4xl font-bold">Simple plans for intentional conversations</h1>
+        <p className="mx-auto max-w-2xl text-muted-foreground">
+          Whether you are meeting one-on-one or guiding a room full of people, DeepTalks helps you keep
+          conversations meaningful, structured, and engaging. Pick the plan that unlocks the right tools for you.
+        </p>
+      </header>
+
+      <section className="grid gap-6 md:grid-cols-3">
+        {tiers.map((tier) => (
+          <article
+            key={tier.name}
+            className="flex flex-col rounded-2xl border border-border bg-card p-6 shadow-sm"
+          >
+            <div className="mb-4">
+              <h2 className="text-xl font-semibold">{tier.name}</h2>
+              <p className="text-3xl font-bold text-primary">{tier.price}</p>
+            </div>
+            <p className="mb-6 text-sm text-muted-foreground">{tier.description}</p>
+            <ul className="mt-auto space-y-2 text-sm">
+              {tier.features.map((feature) => (
+                <li key={feature} className="flex items-start gap-2">
+                  <span aria-hidden className="mt-1 h-2 w-2 rounded-full bg-primary" />
+                  <span>{feature}</span>
+                </li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </section>
+
+      <section className="rounded-2xl border border-dashed border-primary/40 bg-primary/5 p-8 text-center">
+        <h2 className="text-2xl font-semibold">Need a custom plan?</h2>
+        <p className="mt-2 text-muted-foreground">
+          Tell us about your organisation or event and we will tailor DeepTalks to your format, language, and
+          facilitation style.
+        </p>
+        <a
+          href="/contact"
+          className="mt-6 inline-flex items-center justify-center rounded-full bg-primary px-6 py-3 text-sm font-medium text-primary-foreground transition hover:bg-primary/90"
+        >
+          Talk to us
+        </a>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add a pricing landing page with plan details, SEO metadata, and CTA to contact the team
- add a free resources landing page with curated downloads and SEO metadata

## Testing
- npm run lint *(fails: JavaScript heap out of memory while running `next lint`)*

------
https://chatgpt.com/codex/tasks/task_e_68dec1a1d1f08327a176eac1c28fa62c